### PR TITLE
Fix dnssec panic

### DIFF
--- a/namedotcom/resource_namedotcom_dnssec.go
+++ b/namedotcom/resource_namedotcom_dnssec.go
@@ -58,9 +58,9 @@ func resourceDNSSECCreate(data *schema.ResourceData, meta interface{}) error {
 	_, err := meta.(*namecom.NameCom).CreateDNSSEC(
 		&namecom.DNSSEC{
 			DomainName: data.Get("domain_name").(string),
-			KeyTag:     data.Get("key_tag").(int32),
-			Algorithm:  data.Get("algorithm").(int32),
-			DigestType: data.Get("digest_type").(int32),
+			KeyTag:     int32(data.Get("key_tag").(int)),
+			Algorithm:  int32(data.Get("algorithm").(int)),
+			DigestType: int32(data.Get("digest_type").(int)),
 			Digest:     data.Get("digest").(string),
 		},
 	)


### PR DESCRIPTION
# Fix panic in dnssec resource

## Description

Fix a panic caused by a cast of an int to int32:

```text
Stack trace from the terraform-provider-namedotcom_v1.3.1 plugin:

panic: interface conversion: interface {} is int, not int32

goroutine 67 [running]:
github.com/lexfrei/terraform-provider-namedotcom/namedotcom.resourceDNSSECCreate(0x0?, {0x1031ba8c0?, 0x14000142580})
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x1031cfca0?, {0x1031cfca0?, 0x14000458420?}, 0xd
?, {0x1031ba8c0?, 0x14000142580?})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:695 +0x134
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x14000204b60, {0x1031cfca0, 0x14000458420}, 0x140
0072c410, 0x14000704600, {0x1031ba8c0, 0x14000142580})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:837 +0x85c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x1400036df98, {0x1031cfca
0?, 0x14000458300?}, 0x1400045c050)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/grpc_provider.go:1021 +0xb5c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x14000239680, {0x1031cfca0?, 0x1400
019c660?}, 0x140007301c0)
        github.com/hashicorp/terraform-plugin-go@v0.15.0/tfprotov5/tf5server/server.go:818 +0x3b8
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x1031901a0?, 0x14
000239680}, {0x1031cfca0, 0x1400019c660}, 0x14000730150, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.15.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:419 +0x164
google.golang.org/grpc.(*Server).processUnaryRPC(0x140001921e0, {0x1031d3ab8, 0x140001029c0}, 0x14000444480, 0x140002f3c50, 0x1
0372b540, 0x0)
        google.golang.org/grpc@v1.54.0/server.go:1345 +0xc28
google.golang.org/grpc.(*Server).handleStream(0x140001921e0, {0x1031d3ab8, 0x140001029c0}, 0x14000444480, 0x0)
        google.golang.org/grpc@v1.54.0/server.go:1722 +0x80c
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        google.golang.org/grpc@v1.54.0/server.go:966 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.54.0/server.go:964 +0x278

Error: The terraform-provider-namedotcom_v1.3.1 plugin crashed!
```

## Todos

- [ ] Tests
- [x] Documentation; not relevant
- [x] Release note

## Release Note

```release-note
Fixed `panic: interface conversion: interface {} is int, not int32` panic in `dnssec` resource
```