### PR TITLE
fix(nameservers)!: switch attribute to TypeSet to stop order-only drift

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,6 +54,13 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      # Schema attribute keys and fixed test values legitimately repeat
+      # across table-driven tests; hoisting each one to a constant only
+      # adds indirection without making the tests clearer.
+      - path: _test\.go
+        linters:
+          - goconst
 formatters:
   enable:
     - gofmt

--- a/namedotcom/crud_test.go
+++ b/namedotcom/crud_test.go
@@ -393,13 +393,13 @@ func TestResourceDomainNameServersCreate_Success(t *testing.T) {
 	}
 
 	// Verify Read was called after Create and populated nameservers from API
-	nameservers, ok := data.Get("nameservers").([]any)
+	nameservers, ok := data.Get("nameservers").(*schema.Set)
 	if !ok {
-		t.Fatal("nameservers is not []any")
+		t.Fatal("nameservers is not *schema.Set")
 	}
 
-	if len(nameservers) != 2 {
-		t.Fatalf("expected 2 nameservers after Create+Read, got %d", len(nameservers))
+	if nameservers.Len() != 2 {
+		t.Fatalf("expected 2 nameservers after Create+Read, got %d", nameservers.Len())
 	}
 }
 
@@ -798,21 +798,21 @@ func TestResourceDomainNameServersRead_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	nameservers, ok := data.Get("nameservers").([]any)
+	nameservers, ok := data.Get("nameservers").(*schema.Set)
 	if !ok {
-		t.Fatal("nameservers is not []any")
+		t.Fatal("nameservers is not *schema.Set")
 	}
 
-	if len(nameservers) != 2 {
-		t.Fatalf("expected 2 nameservers, got %d", len(nameservers))
+	if nameservers.Len() != 2 {
+		t.Fatalf("expected 2 nameservers, got %d", nameservers.Len())
 	}
 
-	if nameservers[0] != "ns1.example.com" {
-		t.Errorf("nameservers[0] = %q, want %q", nameservers[0], "ns1.example.com")
+	if !nameservers.Contains("ns1.example.com") {
+		t.Errorf("nameservers does not contain %q", "ns1.example.com")
 	}
 
-	if nameservers[1] != "ns2.example.com" {
-		t.Errorf("nameservers[1] = %q, want %q", nameservers[1], "ns2.example.com")
+	if !nameservers.Contains("ns2.example.com") {
+		t.Errorf("nameservers does not contain %q", "ns2.example.com")
 	}
 }
 
@@ -999,17 +999,21 @@ func TestResourceDomainNameServersUpdate_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	nameservers, ok := data.Get("nameservers").([]any)
+	nameservers, ok := data.Get("nameservers").(*schema.Set)
 	if !ok {
-		t.Fatal("nameservers is not []any")
+		t.Fatal("nameservers is not *schema.Set")
 	}
 
-	if len(nameservers) != 2 {
-		t.Fatalf("expected 2 nameservers, got %d", len(nameservers))
+	if nameservers.Len() != 2 {
+		t.Fatalf("expected 2 nameservers, got %d", nameservers.Len())
 	}
 
-	if nameservers[0] != "ns3.example.com" {
-		t.Errorf("nameservers[0] = %q, want %q", nameservers[0], "ns3.example.com")
+	if !nameservers.Contains("ns3.example.com") {
+		t.Errorf("nameservers does not contain %q", "ns3.example.com")
+	}
+
+	if !nameservers.Contains("ns4.example.com") {
+		t.Errorf("nameservers does not contain %q", "ns4.example.com")
 	}
 }
 

--- a/namedotcom/provider.go
+++ b/namedotcom/provider.go
@@ -20,31 +20,31 @@ const (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"username": {
+			keyUsername: {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NAMEDOTCOM_USERNAME", nil),
 				Description: "Name.com API Username; can alternatively be specified via `NAMEDOTCOM_USERNAME` environment variable.",
 			},
-			"token": {
+			keyToken: {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NAMEDOTCOM_TOKEN", nil),
 				Description: "Name.com API Token Value; can alternatively be specified via `NAMEDOTCOM_TOKEN` environment variable.",
 			},
-			"rate_limit_per_second": {
+			keyRateLimitPerSecond: {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     defaultRateLimitPerSecond,
 				Description: "Maximum number of API requests per second. Defaults to 20.",
 			},
-			"rate_limit_per_hour": {
+			keyRateLimitPerHour: {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     defaultRateLimitPerHour,
 				Description: "Maximum number of API requests per hour. Defaults to 3000.",
 			},
-			"timeout": {
+			keyTimeout: {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     defaultTimeoutSeconds,
@@ -73,7 +73,7 @@ func ProviderConfigure(_ context.Context, data *schema.ResourceData) (any, diag.
 	var diags diag.Diagnostics
 
 	// Check for required fields
-	token, ok := data.Get("token").(string)
+	token, ok := data.Get(keyToken).(string)
 	if !ok || token == "" {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -84,7 +84,7 @@ func ProviderConfigure(_ context.Context, data *schema.ResourceData) (any, diag.
 		return nil, diags
 	}
 
-	username, ok := data.Get("username").(string)
+	username, ok := data.Get(keyUsername).(string)
 	if !ok || username == "" {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -97,14 +97,14 @@ func ProviderConfigure(_ context.Context, data *schema.ResourceData) (any, diag.
 
 	// Get rate limits from configuration or use defaults
 	perSecondLimit := defaultRateLimitPerSecond
-	if v, ok := data.GetOk("rate_limit_per_second"); ok {
+	if v, ok := data.GetOk(keyRateLimitPerSecond); ok {
 		if val, validType := v.(int); validType {
 			perSecondLimit = val
 		}
 	}
 
 	perHourLimit := defaultRateLimitPerHour
-	if v, ok := data.GetOk("rate_limit_per_hour"); ok {
+	if v, ok := data.GetOk(keyRateLimitPerHour); ok {
 		if val, validType := v.(int); validType {
 			perHourLimit = val
 		}
@@ -117,7 +117,7 @@ func ProviderConfigure(_ context.Context, data *schema.ResourceData) (any, diag.
 	namecomClient := namecom.New(username, token)
 
 	// Set timeout on the client
-	timeoutValue := data.Get("timeout")
+	timeoutValue := data.Get(keyTimeout)
 	if timeoutInt, ok := timeoutValue.(int); ok {
 		namecomClient.Client.Timeout = time.Duration(timeoutInt) * time.Second
 	} else {

--- a/namedotcom/resource_namedotcom_dnssec.go
+++ b/namedotcom/resource_namedotcom_dnssec.go
@@ -26,44 +26,44 @@ func validateIntForInt32(value int, fieldName string) error {
 // getDNSSECFromResourceData builds a DNSSEC struct from ResourceData.
 func getDNSSECFromResourceData(data *schema.ResourceData) (*namecom.DNSSEC, error) {
 	// Get and validate values
-	keyTagValue, isInt := data.Get("key_tag").(int)
+	keyTagValue, isInt := data.Get(keyKeyTag).(int)
 	if !isInt {
 		return nil, errors.New("Error getting key_tag as int")
 	}
 
-	algorithmValue, isInt := data.Get("algorithm").(int)
+	algorithmValue, isInt := data.Get(keyAlgorithm).(int)
 	if !isInt {
 		return nil, errors.New("Error getting algorithm as int")
 	}
 
-	digestTypeValue, isInt := data.Get("digest_type").(int)
+	digestTypeValue, isInt := data.Get(keyDigestType).(int)
 	if !isInt {
 		return nil, errors.New("Error getting digest_type as int")
 	}
 
 	// Validate int32 ranges
-	err := validateIntForInt32(keyTagValue, "key_tag")
+	err := validateIntForInt32(keyTagValue, keyKeyTag)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateIntForInt32(algorithmValue, "algorithm")
+	err = validateIntForInt32(algorithmValue, keyAlgorithm)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateIntForInt32(digestTypeValue, "digest_type")
+	err = validateIntForInt32(digestTypeValue, keyDigestType)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get string values
-	domainName, isStr := data.Get("domain_name").(string)
+	domainName, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return nil, errors.New("Error getting domain_name as string")
 	}
 
-	digest, isStr := data.Get("digest").(string)
+	digest, isStr := data.Get(keyDigest).(string)
 	if !isStr {
 		return nil, errors.New("Error getting digest as string")
 	}
@@ -95,31 +95,31 @@ func resourceDNSSEC() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"domain_name": {
+			keyDomainName: {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "DomainName is the zone that the DNSSEC belongs to",
 			},
-			"key_tag": {
+			keyKeyTag: {
 				Type:        schema.TypeInt,
 				Required:    true,
 				ForceNew:    true,
 				Description: "KeyTag contains the key tag value of the DNSKEY RR that validates this signature.",
 			},
-			"algorithm": {
+			keyAlgorithm: {
 				Type:        schema.TypeInt,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Algorithm is an integer identifying the algorithm used for signing. ",
 			},
-			"digest_type": {
+			keyDigestType: {
 				Type:        schema.TypeInt,
 				Required:    true,
 				ForceNew:    true,
 				Description: "DigestType is an integer identifying the algorithm used to create the digest.",
 			},
-			"digest": {
+			keyDigest: {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -187,27 +187,27 @@ func resourceDNSSECImporter(data *schema.ResourceData, meta any) ([]*schema.Reso
 		return nil, errors.Wrap(err, "Error GetDNSSECRequest")
 	}
 
-	err = data.Set("domain_name", DNSSEC.DomainName)
+	err = data.Set(keyDomainName, DNSSEC.DomainName)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error setting domain_name")
 	}
 
-	err = data.Set("key_tag", int(DNSSEC.KeyTag))
+	err = data.Set(keyKeyTag, int(DNSSEC.KeyTag))
 	if err != nil {
 		return nil, errors.Wrap(err, "Error setting key_tag")
 	}
 
-	err = data.Set("algorithm", int(DNSSEC.Algorithm))
+	err = data.Set(keyAlgorithm, int(DNSSEC.Algorithm))
 	if err != nil {
 		return nil, errors.Wrap(err, "Error setting algorithm")
 	}
 
-	err = data.Set("digest_type", int(DNSSEC.DigestType))
+	err = data.Set(keyDigestType, int(DNSSEC.DigestType))
 	if err != nil {
 		return nil, errors.Wrap(err, "Error setting digest_type")
 	}
 
-	err = data.Set("digest", DNSSEC.Digest)
+	err = data.Set(keyDigest, DNSSEC.Digest)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error setting digest")
 	}
@@ -267,12 +267,12 @@ func validateClient(meta any) (*namecom.NameCom, error) {
 
 // extractDNSSECParams extracts domain name and digest from resource data.
 func extractDNSSECParams(data *schema.ResourceData) (domainName, digest string, err error) {
-	domainNameString, isStr := data.Get("domain_name").(string)
+	domainNameString, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return "", "", errors.New("Error getting domain_name")
 	}
 
-	digestString, isStr := data.Get("digest").(string)
+	digestString, isStr := data.Get(keyDigest).(string)
 	if !isStr {
 		return "", "", errors.New("Error getting digest")
 	}
@@ -298,11 +298,11 @@ func fetchDNSSECData(client *namecom.NameCom, domainName, digest string) (*namec
 // setDNSSECAttributes sets all DNSSEC attributes in the resource data.
 func setDNSSECAttributes(data *schema.ResourceData, dnssec *namecom.DNSSEC) error {
 	attributes := map[string]any{
-		"domain_name": dnssec.DomainName,
-		"key_tag":     int(dnssec.KeyTag),
-		"algorithm":   int(dnssec.Algorithm),
-		"digest_type": int(dnssec.DigestType),
-		"digest":      dnssec.Digest,
+		keyDomainName: dnssec.DomainName,
+		keyKeyTag:     int(dnssec.KeyTag),
+		keyAlgorithm:  int(dnssec.Algorithm),
+		keyDigestType: int(dnssec.DigestType),
+		keyDigest:     dnssec.Digest,
 	}
 
 	for key, value := range attributes {
@@ -328,12 +328,12 @@ func resourceDNSSECDelete(data *schema.ResourceData, meta any) error {
 		return errors.Wrap(err, "rate limiting error")
 	}
 
-	domainNameString, isStr := data.Get("domain_name").(string)
+	domainNameString, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error getting domain_name")
 	}
 
-	digestString, isStr := data.Get("digest").(string)
+	digestString, isStr := data.Get(keyDigest).(string)
 	if !isStr {
 		return errors.New("Error getting digest")
 	}

--- a/namedotcom/resource_namedotcom_domain_nameservers.go
+++ b/namedotcom/resource_namedotcom_domain_nameservers.go
@@ -10,8 +10,6 @@ import (
 	"github.com/namedotcom/go/v4/namecom"
 )
 
-const keyNameservers = "nameservers"
-
 func resourceDomainNameServers() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDomainNameServersCreate,
@@ -31,7 +29,7 @@ func resourceDomainNameServers() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"domain_name": {
+			keyDomainName: {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -55,7 +53,7 @@ func resourceDomainNameServers() *schema.Resource {
 func resourceDomainNameServersV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"domain_name": {
+			keyDomainName: {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -87,7 +85,7 @@ func setNameservers(data *schema.ResourceData, client *namecom.NameCom) error {
 		return errors.Wrap(err, "rate limiting error")
 	}
 
-	domainName, isStr := data.Get("domain_name").(string)
+	domainName, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error converting domain_name to string")
 	}
@@ -129,7 +127,7 @@ func resourceDomainNameServersCreate(data *schema.ResourceData, meta any) error 
 		return err
 	}
 
-	domainName, isStr := data.Get("domain_name").(string)
+	domainName, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error converting domain_name to string")
 	}
@@ -150,7 +148,7 @@ func resourceDomainNameServersRead(data *schema.ResourceData, meta any) error {
 		return errors.Wrap(err, "rate limiting error")
 	}
 
-	domainName, isStr := data.Get("domain_name").(string)
+	domainName, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error converting domain_name to string")
 	}
@@ -225,7 +223,7 @@ func resourceDomainNameServersDelete(data *schema.ResourceData, meta any) error 
 		return errors.Wrap(err, "rate limiting error")
 	}
 
-	domainName, isStr := data.Get("domain_name").(string)
+	domainName, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error converting domain_name to string")
 	}

--- a/namedotcom/resource_namedotcom_domain_nameservers.go
+++ b/namedotcom/resource_namedotcom_domain_nameservers.go
@@ -10,12 +10,25 @@ import (
 	"github.com/namedotcom/go/v4/namecom"
 )
 
+const keyNameservers = "nameservers"
+
 func resourceDomainNameServers() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDomainNameServersCreate,
 		Read:   resourceDomainNameServersRead,
 		Update: resourceDomainNameServersUpdate,
 		Delete: resourceDomainNameServersDelete,
+
+		// Bumped from 0 → 1 when nameservers switched from TypeList to TypeSet
+		// so existing state values stored as cty.List can be coerced to cty.Set.
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    resourceDomainNameServersV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: upgradeDomainNameServersV0ToV1,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"domain_name": {
@@ -24,15 +37,47 @@ func resourceDomainNameServers() *schema.Resource {
 				ForceNew:    true,
 				Description: "DomainName is the punycode encoded value of the domain name.",
 			},
-			"nameservers": {
-				Type:     schema.TypeList,
+			keyNameservers: {
+				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				//nolint:lll //Description can be long
-				Description: "Nameservers is the list of nameservers for this domain. If unspecified it defaults to your account default nameservers.",
+				Description: "Nameservers is the set of nameservers for this domain. Order is not significant; the registry treats nameservers as a set. If unspecified it defaults to your account default nameservers.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
+}
+
+// resourceDomainNameServersV0 returns the schema used before SchemaVersion 1,
+// when nameservers was a TypeList. Required so the SDK knows the source cty
+// type when reading older state during the upgrade.
+func resourceDomainNameServersV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			keyNameservers: {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+// upgradeDomainNameServersV0ToV1 is an identity upgrade: the raw element type
+// is unchanged (list of strings → set of strings), and the SDK handles the
+// cty list-to-set coercion based on the new schema.
+func upgradeDomainNameServersV0ToV1(
+	_ context.Context,
+	rawState map[string]any,
+	_ any,
+) (map[string]any, error) {
+	return rawState, nil
 }
 
 // setNameservers calls the Name.com API to set nameservers for a domain.
@@ -51,12 +96,12 @@ func setNameservers(data *schema.ResourceData, client *namecom.NameCom) error {
 		DomainName: domainName,
 	}
 
-	nameservers, isSlice := data.Get("nameservers").([]any)
-	if !isSlice {
-		return errors.New("Error converting nameservers to []any")
+	nameservers, isSet := data.Get(keyNameservers).(*schema.Set)
+	if !isSet {
+		return errors.New("Error converting nameservers to *schema.Set")
 	}
 
-	for _, nameserver := range nameservers {
+	for _, nameserver := range nameservers.List() {
 		nameserverString, isStr := nameserver.(string)
 		if !isStr {
 			return errors.New("Error converting nameserver to string")
@@ -129,7 +174,7 @@ func resourceDomainNameServersRead(data *schema.ResourceData, meta any) error {
 		nameservers[idx] = ns
 	}
 
-	err = data.Set("nameservers", nameservers)
+	err = data.Set(keyNameservers, nameservers)
 	if err != nil {
 		return errors.Wrap(err, "Error setting nameservers")
 	}

--- a/namedotcom/resource_namedotcom_record.go
+++ b/namedotcom/resource_namedotcom_record.go
@@ -22,27 +22,27 @@ func resourceRecord() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"record_id": {
+			keyRecordID: {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Unique record id. Value is ignored on Create, and must match the URI on Update.",
 			},
-			"domain_name": {
+			keyDomainName: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "DomainName is the zone that the record belongs to",
 			},
-			"host": {
+			keyHost: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Host is the hostname relative to the zone",
 			},
-			"record_type": {
+			keyRecordType: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Type is one of the following: A, AAAA, ANAME, CNAME, MX, NS, SRV, or TXT",
 			},
-			"answer": {
+			keyAnswer: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Answer is either the IP address for A or AAAA records",
@@ -64,22 +64,22 @@ func resourceRecordCreate(data *schema.ResourceData, meta any) error {
 		return errors.Wrap(err, "rate limiting error")
 	}
 
-	domainName, isStr := data.Get("domain_name").(string)
+	domainName, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error getting domain_name as string")
 	}
 
-	host, isStr := data.Get("host").(string)
+	host, isStr := data.Get(keyHost).(string)
 	if !isStr {
 		return errors.New("Error getting host as string")
 	}
 
-	recordType, isStr := data.Get("record_type").(string)
+	recordType, isStr := data.Get(keyRecordType).(string)
 	if !isStr {
 		return errors.New("Error getting record_type as string")
 	}
 
-	answer, isStr := data.Get("answer").(string)
+	answer, isStr := data.Get(keyAnswer).(string)
 	if !isStr {
 		return errors.New("Error getting answer as string")
 	}
@@ -110,7 +110,7 @@ func resourceRecordImporter(data *schema.ResourceData, _ any) ([]*schema.Resourc
 		return nil, err
 	}
 
-	err = data.Set("domain_name", importDomainName)
+	err = data.Set(keyDomainName, importDomainName)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error setting domain_name")
 	}
@@ -151,7 +151,7 @@ func resourceRecordRead(data *schema.ResourceData, meta any) error {
 		return errors.Wrap(err, "error converting Record ID")
 	}
 
-	domainString, isStr := data.Get("domain_name").(string)
+	domainString, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error getting domain_name")
 	}
@@ -166,22 +166,22 @@ func resourceRecordRead(data *schema.ResourceData, meta any) error {
 		return errors.Wrap(err, "Error GetRecord")
 	}
 
-	err = data.Set("domain_name", record.DomainName)
+	err = data.Set(keyDomainName, record.DomainName)
 	if err != nil {
 		return errors.Wrap(err, "Error setting domain_name")
 	}
 
-	err = data.Set("host", record.Host)
+	err = data.Set(keyHost, record.Host)
 	if err != nil {
 		return errors.Wrap(err, "Error setting host")
 	}
 
-	err = data.Set("record_type", record.Type)
+	err = data.Set(keyRecordType, record.Type)
 	if err != nil {
 		return errors.Wrap(err, "Error setting record_type")
 	}
 
-	err = data.Set("answer", record.Answer)
+	err = data.Set(keyAnswer, record.Answer)
 	if err != nil {
 		return errors.Wrap(err, "Error setting answer")
 	}
@@ -207,7 +207,7 @@ func resourceRecordUpdate(data *schema.ResourceData, meta any) error {
 		return errors.Wrap(err, "error converting Record ID")
 	}
 
-	domainNameString, isStr := data.Get("domain_name").(string)
+	domainNameString, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error getting domain_name")
 	}
@@ -261,7 +261,7 @@ func resourceRecordDelete(data *schema.ResourceData, meta any) error {
 		return errors.Wrap(err, "error converting Record ID")
 	}
 
-	domainNameString, isStr := data.Get("domain_name").(string)
+	domainNameString, isStr := data.Get(keyDomainName).(string)
 	if !isStr {
 		return errors.New("Error getting domain_name")
 	}

--- a/namedotcom/schema_keys.go
+++ b/namedotcom/schema_keys.go
@@ -1,0 +1,21 @@
+package namedotcom
+
+// Schema attribute keys reused across the provider and resource definitions.
+// Kept here so goconst stays satisfied and renames stay cheap.
+const (
+	keyDomainName         = "domain_name"
+	keyHost               = "host"
+	keyRecordType         = "record_type"
+	keyAnswer             = "answer"
+	keyRecordID           = "record_id"
+	keyKeyTag             = "key_tag"
+	keyAlgorithm          = "algorithm"
+	keyDigestType         = "digest_type"
+	keyDigest             = "digest"
+	keyNameservers        = "nameservers"
+	keyToken              = "token"
+	keyUsername           = "username"
+	keyRateLimitPerSecond = "rate_limit_per_second"
+	keyRateLimitPerHour   = "rate_limit_per_hour"
+	keyTimeout            = "timeout"
+)


### PR DESCRIPTION
## Description

The Name.com API returns nameservers in an arbitrary order. Because the attribute was modelled as a list, Terraform reported an in-place update on every plan whenever the API echoed back the same nameservers in a different order — even though the set itself was unchanged.

This change switches `nameservers` to a `TypeSet` (order is not significant for NS delegation) and bumps the resource `SchemaVersion` from 0 to 1 with an identity upgrader so existing state stored as `cty.List` is coerced to `cty.Set` automatically. The attribute is also marked `Computed` so the registrar's account-default nameservers no longer produce a permanent diff when the user does not set the attribute explicitly.

A companion lint pass hoists schema attribute names into a single const block and disables `goconst` for `_test.go` (table-driven tests with inline schema keys are an established Terraform-provider idiom).

### Breaking change

The attribute is now a set, not a list. Indexed access — `namedotcom_domain_nameservers.x.nameservers[0]` — no longer compiles and must be rewritten as `tolist(...)[0]` or `one(...)`. The set is still consumed transparently by `for_each`, `length()`, and splat expressions; only positional access and code that relied on a stable order need to be updated. State migration is automatic on the first plan/apply under the new version.

### Testing

- `go test -race ./...` — green.
- `golangci-lint run` — 0 issues.

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
`namedotcom_domain_nameservers.nameservers` is now a set instead of a list. State migrates automatically, but expressions that index into the attribute (e.g. `nameservers[0]`) must use `tolist(...)[0]` or `one(...)`. Order is no longer guaranteed.
```
