### PR TITLE
docs: add BSD-3-Clause license and tidy README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2019 Mike Hume
+Copyright (c) 2022-2026 Aleksei Sviridkin
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [BSD 3-Clause License](LICENSE).
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,6 @@ A Terraform provider that allows you to manage your [Name.com](https://name.com)
 >
 > I strongly recommend migrating to [OpenTofu](https://opentofu.org/) — a drop-in replacement for Terraform with a reliable, community-driven registry.
 
-## Upgrading to v4.0.0
-
-v4.0.0 rebuilds the provider on the Terraform Plugin Framework. There are two breaking changes to be aware of:
-
-- **Minimum tooling**: the provider now serves protocol 6 and requires Terraform >= 1.0 or any OpenTofu version.
-- **`record_id` is now read-only**: it was always assigned by Name.com, so it is now a computed attribute. If you set `record_id` explicitly in a `namedotcom_record` block, remove it — `terraform plan` will otherwise reject it as a read-only attribute. The record's identifier is exposed as the computed `id` (and mirrored as the numeric `record_id`).
-
-Existing state migrates automatically — no manual state edits are required and no resources are replaced. `domain_name` and `record_type` force replacement only on a genuine change; a difference that is purely DNS canonicalization (letter case, or a trailing dot on the answer) does not, so records created by older versions are not destroyed and recreated. The first plan after upgrading may show benign in-place updates: the now-computed `record_id` populates from the API, and `record_type`/`answer` normalize to the representation in your configuration. These are cosmetic refreshes, not replacements.
-
 ## Installation
 
 ### Using OpenTofu Registry (Recommended)


### PR DESCRIPTION
## Description

Add the missing license file and bring the README in line with it. This is a documentation-only change.

Why: the repository shipped without a license file, which blocks Terraform/OpenTofu Registry publishing and leaves the dynamic license badge unable to resolve. The README's license section also claimed MIT, which never matched any actual license of the project.

What changed:

- Add a BSD-3-Clause `LICENSE`. Copyright preserves the original author's attribution alongside the current maintainer's.
- Correct the README license reference from MIT to BSD-3-Clause.
- Drop the v4.0.0 upgrade guide from the README — version-specific notes belong in the release notes, not the evergreen README.

Testing: no code paths are touched; `markdownlint` passes on the README. The license badge resolves to BSD-3-Clause once GitHub indexes the new `LICENSE`.

Components affected: documentation only (`LICENSE`, `README.md`).

## Todos

- [ ] Tests <!-- N/A: documentation-only change, no code paths touched -->
- [x] Documentation
- [x] Release note

## Release Note

```release-note
Add a BSD-3-Clause LICENSE file and correct the README license reference (previously listed as MIT).
```
