### PR TITLE
feat(record): support priority for MX and SRV records

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,134 +83,86 @@ provider "namedotcom" {
 
 ## Usage Examples
 
-### Managing DNS Records
+A realistic configuration that exercises every resource the provider offers. It manages two domains with different strategies: `example.com` is hosted directly on Name.com, while `example.net` is delegated to an external DNS provider and secured with DNSSEC.
 
 ```hcl
-# Create an A record
-resource "namedotcom_record" "website" {
+provider "namedotcom" {
+  # Credentials can also come from the NAMEDOTCOM_USERNAME and
+  # NAMEDOTCOM_TOKEN environment variables.
+  username = var.namedotcom_username
+  token    = var.namedotcom_token
+
+  # Optional: tune the built-in rate limiter (defaults shown).
+  rate_limit_per_second = 20
+  rate_limit_per_hour   = 3000
+}
+
+# --- example.com: DNS hosted on Name.com -------------------------------------
+
+# Apex A record: an empty host targets the bare domain (example.com).
+resource "namedotcom_record" "apex" {
   domain_name = "example.com"
-  host        = "www"
+  host        = ""
   record_type = "A"
   answer      = "192.0.2.1"
 }
 
-# Create a CNAME record
-resource "namedotcom_record" "alias" {
+# IPv6 address for the apex.
+resource "namedotcom_record" "apex_v6" {
   domain_name = "example.com"
-  host        = "blog"
+  host        = ""
+  record_type = "AAAA"
+  answer      = "2001:db8::1"
+}
+
+# www as a CNAME pointing back to the apex.
+resource "namedotcom_record" "www" {
+  domain_name = "example.com"
+  host        = "www"
   record_type = "CNAME"
-  answer      = "www.example.com"
+  answer      = "example.com"
 }
 
-# Create multiple records for the same domain
-resource "namedotcom_record" "multi_records" {
+# Mail exchanger. MX records use priority; a lower value is preferred.
+resource "namedotcom_record" "mail" {
   domain_name = "example.com"
-  record_type = "A"
-  
-  for_each = {
-    ""      = "192.0.2.1"  # Apex domain
-    "www"   = "192.0.2.1"
-    "api"   = "192.0.2.2"
-    "admin" = "192.0.2.3"
-  }
-
-  host   = each.key
-  answer = each.value
-}
-```
-
-### Setting Custom Nameservers
-
-```hcl
-# Use custom nameservers (e.g., with AWS Route 53)
-resource "aws_route53_zone" "example_zone" {
-  name = "example.com"
+  host        = ""
+  record_type = "MX"
+  answer      = "mail.example.com"
+  priority    = 10
 }
 
-resource "namedotcom_domain_nameservers" "example_nameservers" {
+# SPF policy as a TXT record on the apex.
+resource "namedotcom_record" "spf" {
   domain_name = "example.com"
+  host        = ""
+  record_type = "TXT"
+  answer      = "v=spf1 -all"
+}
+
+# --- example.net: delegated to an external DNS provider, secured with DNSSEC -
+
+# Point the domain at the external provider's nameservers.
+resource "namedotcom_domain_nameservers" "example_net" {
+  domain_name = "example.net"
   nameservers = [
-    aws_route53_zone.example_zone.name_servers[0],
-    aws_route53_zone.example_zone.name_servers[1],
-    aws_route53_zone.example_zone.name_servers[2],
-    aws_route53_zone.example_zone.name_servers[3],
+    "ns1.dns.example",
+    "ns2.dns.example",
   ]
 }
-```
 
-### Setting Up DNSSEC
-
-```hcl
-# Configure DNSSEC with AWS Route 53
-resource "aws_route53_zone" "example_zone" {
-  name = "example.com"
-}
-
-resource "aws_route53_key_signing_key" "example_ksk" {
-  name                       = "example-key"
-  hosted_zone_id             = aws_route53_zone.example_zone.id
-  key_management_service_arn = aws_kms_key.example_kms.arn
-}
-
-resource "aws_route53_hosted_zone_dnssec" "example" {
-  hosted_zone_id = aws_route53_zone.example_zone.id
-}
-
-resource "namedotcom_dnssec" "example_dnssec" {
-  domain_name = "example.com"
-  key_tag     = aws_route53_key_signing_key.example_ksk.key_tag
-  algorithm   = aws_route53_key_signing_key.example_ksk.signing_algorithm_type
-  digest_type = aws_route53_key_signing_key.example_ksk.digest_algorithm_type
-  digest      = aws_route53_key_signing_key.example_ksk.digest_value
+# Register the DS record so the delegated zone is validated by the registry.
+# These values come from the external DNS provider's key-signing key.
+resource "namedotcom_dnssec" "example_net" {
+  domain_name = "example.net"
+  key_tag     = 12345
+  algorithm   = 13
+  digest_type = 2
+  digest      = "6B3ED3311DE85004BF6DD325BA82340BC89B40B86D4055780F3BE4390B81B59A"
 }
 ```
 
-### API Rate Limiting
-
-The provider includes built-in rate limiting to prevent hitting Name.com's API limits. The defaults should work for most use cases, but you can adjust them if needed:
-
-```hcl
-provider "namedotcom" {
-  username = var.namedotcom_username
-  token    = var.namedotcom_token
-  
-  # Optional rate limiting configuration
-  rate_limit_per_second = 20   # Default: 20
-  rate_limit_per_hour   = 3000 # Default: 3000
-}
-```
-
-## Resource Importing
-
-### Importing DNS Records
-
-To import existing DNS records into your Terraform state:
-
-```bash
-# Format: terraform import namedotcom_record.[resource_name] [domain_name]:[record_id]
-terraform import namedotcom_record.website example.com:12345
-
-# For records in a for_each block
-terraform import 'namedotcom_record.multi_records["www"]' example.com:12345
-```
-
-To find the record ID, use the Name.com API:
-
-```bash
-curl -u 'username:token' 'https://api.name.com/v4/domains/example.com/records'
-```
-
-### Importing DNSSEC Settings
-
-To import existing DNSSEC settings:
-
-```bash
-# Format: terraform import namedotcom_dnssec.[resource_name] [domain_name]_[digest]
-terraform import namedotcom_dnssec.example_dnssec example.com_6B3ED3311DE85004BF6DD325BA82340BC89B40B86D4055780F3BE4390B81B59A
-
-# For resources in a for_each block
-terraform import 'namedotcom_dnssec.dnssec["example.com"]' example.com_6B3ED3311DE85004BF6DD325BA82340BC89B40B86D4055780F3BE4390B81B59A
-```
+> Hosting a zone's records on Name.com and delegating that same zone elsewhere are mutually exclusive — once a domain is delegated, its records live with the other provider. See the [per-resource docs](#resource-documentation) for the full attribute reference and import syntax.
 
 ## Resource Documentation
 

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -28,6 +28,16 @@ resource "namedotcom_record" "foo" {
   record_type = "A"
   answer = "192.0.2.3"
 }
+
+// example.com MX -> mail.example.com (lower priority is preferred)
+
+resource "namedotcom_record" "mail" {
+  domain_name = "example.com"
+  host = ""
+  record_type = "MX"
+  answer = "mail.example.com"
+  priority = 10
+}
 ```
 
 Many records per domain example
@@ -56,6 +66,7 @@ resource "namedotcom_record" "domain-me" {
 - `answer` (String) Answer is the record value: the IP address for A and AAAA records, the target for ANAME, CNAME, MX, NS, and SRV records, or the text for TXT records.
 - `domain_name` (String) DomainName is the zone that the record belongs to. Changing this forces a new resource.
 - `host` (String) Host is the hostname relative to the zone.
+- `priority` (Number) Priority is used by MX and SRV records, where a lower value is preferred; it is ignored for all other record types. Valid range is 0-65535.
 - `record_type` (String) Type is one of the following: A, AAAA, ANAME, CNAME, MX, NS, SRV, or TXT. Changing this forces a new resource.
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.4
 require (
 	github.com/cockroachdb/errors v1.14.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/namedotcom/go/v4 v4.0.2
 	golang.org/x/time v0.15.0
 )

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/namedotcom/crud_test.go
+++ b/namedotcom/crud_test.go
@@ -78,7 +78,9 @@ func TestCreateRecordAPI_Success(t *testing.T) {
 
 	client := newMockClient(t, mux)
 
-	record, err := namedotcom.CreateRecordAPI(context.Background(), client, testDomain, "test", "A", "1.2.3.4")
+	record, err := namedotcom.CreateRecordAPI(context.Background(), client, &namecom.Record{
+		DomainName: testDomain, Host: "test", Type: "A", Answer: "1.2.3.4",
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -92,12 +94,54 @@ func TestCreateRecordAPI_Success(t *testing.T) {
 	}
 }
 
+// TestCreateRecordAPI_SendsPriority confirms an MX record's priority reaches the
+// API request body and is read back from the response.
+func TestCreateRecordAPI_SendsPriority(t *testing.T) {
+	initLimiters(t)
+
+	var gotPriority uint32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v4/domains/example.com/records", func(writer http.ResponseWriter, request *http.Request) {
+		var body namecom.Record
+
+		err := json.NewDecoder(request.Body).Decode(&body)
+		if err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+
+		gotPriority = body.Priority
+
+		writer.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(writer, `{"id":42,"domainName":"example.com","host":"","type":"MX","answer":"mail.example.com","priority":10}`)
+	})
+
+	client := newMockClient(t, mux)
+
+	record, err := namedotcom.CreateRecordAPI(context.Background(), client, &namecom.Record{
+		DomainName: testDomain, Host: "", Type: "MX", Answer: "mail.example.com", Priority: 10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotPriority != 10 {
+		t.Errorf("priority sent to API = %d, want 10", gotPriority)
+	}
+
+	if record.Priority != 10 {
+		t.Errorf("record.Priority = %d, want 10", record.Priority)
+	}
+}
+
 func TestCreateRecordAPI_APIError(t *testing.T) {
 	initLimiters(t)
 
 	client := newErrorMock(t, "/v4/domains/example.com/records")
 
-	_, err := namedotcom.CreateRecordAPI(context.Background(), client, testDomain, "test", "A", "1.2.3.4")
+	_, err := namedotcom.CreateRecordAPI(context.Background(), client, &namecom.Record{
+		DomainName: testDomain, Host: "test", Type: "A", Answer: "1.2.3.4",
+	})
 	if err == nil {
 		t.Fatal("expected error from API, got nil")
 	}
@@ -146,7 +190,9 @@ func TestUpdateRecordAPI_Success(t *testing.T) {
 
 	client := newMockClient(t, mux)
 
-	record, err := namedotcom.UpdateRecordAPI(context.Background(), client, 42, testDomain, "test", "A", "5.6.7.8")
+	record, err := namedotcom.UpdateRecordAPI(context.Background(), client, 42, &namecom.Record{
+		DomainName: testDomain, Host: "test", Type: "A", Answer: "5.6.7.8",
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -161,7 +207,9 @@ func TestUpdateRecordAPI_APIError(t *testing.T) {
 
 	client := newErrorMock(t, "/v4/domains/example.com/records/42")
 
-	_, err := namedotcom.UpdateRecordAPI(context.Background(), client, 42, testDomain, "test", "A", "1.2.3.4")
+	_, err := namedotcom.UpdateRecordAPI(context.Background(), client, 42, &namecom.Record{
+		DomainName: testDomain, Host: "test", Type: "A", Answer: "1.2.3.4",
+	})
 	if err == nil {
 		t.Fatal("expected error from API, got nil")
 	}

--- a/namedotcom/record_internal_test.go
+++ b/namedotcom/record_internal_test.go
@@ -8,8 +8,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/namedotcom/go/v4/namecom"
@@ -582,6 +585,133 @@ func TestRecordCreate_MXSetsPriority(t *testing.T) {
 	if got.Priority.ValueInt32() != 10 {
 		t.Errorf("priority = %d, want 10", got.Priority.ValueInt32())
 	}
+}
+
+// TestRecordValidateConfig_PriorityRecordType pins that priority is accepted
+// only on MX and SRV records and rejected on every other type, so a config that
+// would silently drift (the API drops priority for other types) fails fast.
+func TestRecordValidateConfig_PriorityRecordType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		recordType string
+		priority   types.Int32
+		wantErr    bool
+	}{
+		{"priority on MX is allowed", "MX", types.Int32Value(10), false},
+		{"priority on SRV is allowed", "SRV", types.Int32Value(10), false},
+		{"priority on lowercase mx is allowed", "mx", types.Int32Value(10), false},
+		{"priority on A is rejected", "A", types.Int32Value(10), true},
+		{"priority on CNAME is rejected", "CNAME", types.Int32Value(10), true},
+		{"no priority on A is allowed", "A", types.Int32Null(), false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := &recordResource{}
+			req := resource.ValidateConfigRequest{
+				Config: recordConfig(t, recordModel{
+					DomainName: types.StringValue("example.com"),
+					Host:       types.StringValue(""),
+					RecordType: types.StringValue(testCase.recordType),
+					Answer:     types.StringValue("mail.example.com"),
+					Priority:   testCase.priority,
+				}),
+			}
+			resp := &resource.ValidateConfigResponse{}
+
+			res.ValidateConfig(context.Background(), req, resp)
+
+			if resp.Diagnostics.HasError() != testCase.wantErr {
+				t.Errorf("ValidateConfig error = %v, want %v (diags: %v)", resp.Diagnostics.HasError(), testCase.wantErr, resp.Diagnostics)
+			}
+		})
+	}
+}
+
+// TestRecordSchema_PriorityRangeEnforced confirms the documented 0-65535 range
+// is actually enforced by a validator on the attribute, rejecting out-of-range
+// values and accepting the boundaries.
+func TestRecordSchema_PriorityRangeEnforced(t *testing.T) {
+	t.Parallel()
+
+	var schemaResp resource.SchemaResponse
+
+	(&recordResource{}).Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+
+	attr, ok := schemaResp.Schema.Attributes[keyPriority].(schema.Int32Attribute)
+	if !ok {
+		t.Fatalf("priority attribute is %T, want schema.Int32Attribute", schemaResp.Schema.Attributes[keyPriority])
+	}
+
+	if len(attr.Int32Validators()) == 0 {
+		t.Fatal("priority attribute has no validators; the documented 0-65535 range is not enforced")
+	}
+
+	rejected := func(value int32) bool {
+		req := validator.Int32Request{Path: path.Root(keyPriority), ConfigValue: types.Int32Value(value)}
+		resp := &validator.Int32Response{}
+
+		for _, val := range attr.Int32Validators() {
+			val.ValidateInt32(context.Background(), req, resp)
+		}
+
+		return resp.Diagnostics.HasError()
+	}
+
+	cases := []struct {
+		value   int32
+		wantErr bool
+	}{
+		{-1, true},
+		{65536, true},
+		{0, false},
+		{65535, false},
+	}
+
+	for _, testCase := range cases {
+		if got := rejected(testCase.value); got != testCase.wantErr {
+			t.Errorf("priority=%d: validator rejected = %v, want %v", testCase.value, got, testCase.wantErr)
+		}
+	}
+}
+
+// TestPriorityToUint32 covers the unset/unknown branches that map to the API's
+// zero default; concrete values pass through unchanged.
+func TestPriorityToUint32(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input types.Int32
+		want  uint32
+	}{
+		{"null maps to zero", types.Int32Null(), 0},
+		{"unknown maps to zero", types.Int32Unknown(), 0},
+		{"concrete value passes through", types.Int32Value(10), 10},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := priorityToUint32(testCase.input); got != testCase.want {
+				t.Errorf("priorityToUint32(%v) = %d, want %d", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}
+
+// recordConfig builds a tfsdk.Config carrying the record schema and the given
+// model. tfsdk.Config has no Set, so the model is marshalled via State.Set and
+// the resulting Raw value is wrapped in a Config (they share a representation).
+func recordConfig(t *testing.T, model recordModel) tfsdk.Config {
+	t.Helper()
+
+	return tfsdk.Config(recordState(t, model))
 }
 
 // recordPlan builds a tfsdk.Plan carrying the record schema and the given model.

--- a/namedotcom/record_internal_test.go
+++ b/namedotcom/record_internal_test.go
@@ -705,6 +705,117 @@ func TestPriorityToUint32(t *testing.T) {
 	}
 }
 
+// TestRecordUpdate_MXPriorityReset pins the priority 10 -> 0 path. Because the
+// API field is `omitempty`, a zero priority is dropped from the request body;
+// UpdateRecord is a full-replace PUT, so the server resets priority to 0 and
+// state converges. A switch to PATCH semantics would break this and the test.
+func TestRecordUpdate_MXPriorityReset(t *testing.T) {
+	InitRateLimiters(defaultPerSecondLimit, defaultPerHourLimit)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v4/domains/example.com/records/42", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(writer, `{"id":42,"domainName":"example.com","host":"","type":"MX","answer":"mail.example.com","priority":0}`)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	res := &recordResource{client: namecom.Mock("u", "t", server.URL)}
+
+	model := func(priority types.Int32) recordModel {
+		return recordModel{
+			ID:         types.StringValue("42"),
+			RecordID:   types.Int32Value(42),
+			DomainName: types.StringValue("example.com"),
+			Host:       types.StringValue(""),
+			RecordType: types.StringValue("MX"),
+			Answer:     types.StringValue("mail.example.com"),
+			Priority:   priority,
+		}
+	}
+
+	req := resource.UpdateRequest{
+		Plan:  recordPlan(t, model(types.Int32Value(0))),
+		State: recordState(t, model(types.Int32Value(10))),
+	}
+	resp := resource.UpdateResponse{State: recordState(t, model(types.Int32Value(10)))}
+
+	res.Update(context.Background(), req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got recordModel
+
+	resp.State.Get(context.Background(), &got)
+
+	if got.Priority.ValueInt32() != 0 {
+		t.Errorf("priority = %d, want 0 (reset converges)", got.Priority.ValueInt32())
+	}
+}
+
+// TestPriorityToInt32 covers the API-to-schema conversion directly.
+func TestPriorityToInt32(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input uint32
+		want  int32
+	}{
+		{0, 0},
+		{10, 10},
+		{65535, 65535},
+	}
+
+	for _, testCase := range cases {
+		if got := priorityToInt32(testCase.input); got != testCase.want {
+			t.Errorf("priorityToInt32(%d) = %d, want %d", testCase.input, got, testCase.want)
+		}
+	}
+}
+
+// TestRecordValidateConfig_DefersOnUnknown confirms the two defer branches: when
+// either record_type or priority is unknown (computed from another resource),
+// validation is postponed rather than erroring.
+func TestRecordValidateConfig_DefersOnUnknown(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		recordType types.String
+		priority   types.Int32
+	}{
+		{"unknown record_type defers", types.StringUnknown(), types.Int32Value(10)},
+		{"unknown priority defers", types.StringValue("A"), types.Int32Unknown()},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := &recordResource{}
+			req := resource.ValidateConfigRequest{
+				Config: recordConfig(t, recordModel{
+					DomainName: types.StringValue("example.com"),
+					Host:       types.StringValue(""),
+					RecordType: testCase.recordType,
+					Answer:     types.StringValue("mail.example.com"),
+					Priority:   testCase.priority,
+				}),
+			}
+			resp := &resource.ValidateConfigResponse{}
+
+			res.ValidateConfig(context.Background(), req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Errorf("expected validation to defer (no error), got %v", resp.Diagnostics)
+			}
+		})
+	}
+}
+
 // recordConfig builds a tfsdk.Config carrying the record schema and the given
 // model. tfsdk.Config has no Set, so the model is marshalled via State.Set and
 // the resulting Raw value is wrapped in a Config (they share a representation).

--- a/namedotcom/record_internal_test.go
+++ b/namedotcom/record_internal_test.go
@@ -788,6 +788,7 @@ func TestRecordValidateConfig_DefersOnUnknown(t *testing.T) {
 		priority   types.Int32
 	}{
 		{"unknown record_type defers", types.StringUnknown(), types.Int32Value(10)},
+		{"null record_type defers", types.StringNull(), types.Int32Value(10)},
 		{"unknown priority defers", types.StringValue("A"), types.Int32Unknown()},
 	}
 

--- a/namedotcom/record_internal_test.go
+++ b/namedotcom/record_internal_test.go
@@ -507,6 +507,83 @@ func TestRequiresReplaceOnDNSChange(t *testing.T) {
 	}
 }
 
+// TestReconcilePriority pins the drift-avoidance rules for the priority
+// attribute: an unset priority must not flap against the API's zero default,
+// a configured value matching the API is preserved, and a genuine difference
+// (including populating an MX record's priority on import) is adopted.
+func TestReconcilePriority(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		prior    types.Int32
+		apiValue uint32
+		want     types.Int32
+	}{
+		{"unset stays null when API reports the zero default", types.Int32Null(), 0, types.Int32Null()},
+		{"configured value matching the API is preserved", types.Int32Value(10), 10, types.Int32Value(10)},
+		{"unset adopts a non-zero API value (MX import)", types.Int32Null(), 10, types.Int32Value(10)},
+		{"a genuine difference is adopted from the API", types.Int32Value(10), 20, types.Int32Value(20)},
+		{"an explicit zero is preserved", types.Int32Value(0), 0, types.Int32Value(0)},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := reconcilePriority(testCase.prior, testCase.apiValue)
+
+			if !got.Equal(testCase.want) {
+				t.Errorf("reconcilePriority(%v, %d) = %v, want %v", testCase.prior, testCase.apiValue, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestRecordCreate_MXSetsPriority drives Create end to end for an MX record and
+// confirms the configured priority is sent to the API and echoed into state.
+func TestRecordCreate_MXSetsPriority(t *testing.T) {
+	InitRateLimiters(defaultPerSecondLimit, defaultPerHourLimit)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v4/domains/example.com/records", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(writer, `{"id":42,"domainName":"example.com","host":"","type":"MX","answer":"mail.example.com","priority":10}`)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	res := &recordResource{client: namecom.Mock("u", "t", server.URL)}
+
+	req := resource.CreateRequest{
+		Plan: recordPlan(t, recordModel{
+			ID:         types.StringNull(),
+			RecordID:   types.Int32Null(),
+			DomainName: types.StringValue("example.com"),
+			Host:       types.StringValue(""),
+			RecordType: types.StringValue("MX"),
+			Answer:     types.StringValue("mail.example.com"),
+			Priority:   types.Int32Value(10),
+		}),
+	}
+	resp := resource.CreateResponse{State: recordState(t, recordModel{ID: types.StringNull()})}
+
+	res.Create(context.Background(), req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got recordModel
+
+	resp.State.Get(context.Background(), &got)
+
+	if got.Priority.ValueInt32() != 10 {
+		t.Errorf("priority = %d, want 10", got.Priority.ValueInt32())
+	}
+}
+
 // recordPlan builds a tfsdk.Plan carrying the record schema and the given model.
 func recordPlan(t *testing.T, model recordModel) tfsdk.Plan {
 	t.Helper()

--- a/namedotcom/resource_namedotcom_record.go
+++ b/namedotcom/resource_namedotcom_record.go
@@ -36,6 +36,7 @@ type recordModel struct {
 	Host       types.String `tfsdk:"host"`
 	RecordType types.String `tfsdk:"record_type"`
 	Answer     types.String `tfsdk:"answer"`
+	Priority   types.Int32  `tfsdk:"priority"`
 }
 
 // NewRecordResource is the resource factory registered with the provider.
@@ -81,6 +82,11 @@ func (r *recordResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				//nolint:lll // One sentence covering every supported record type.
 				Description: "Answer is the record value: the IP address for A and AAAA records, the target for ANAME, CNAME, MX, NS, and SRV records, or the text for TXT records.",
 			},
+			keyPriority: schema.Int32Attribute{
+				Optional: true,
+				//nolint:lll // One sentence describing where priority applies.
+				Description: "Priority is used by MX and SRV records, where a lower value is preferred; it is ignored for all other record types. Valid range is 0-65535.",
+			},
 		},
 	}
 }
@@ -102,13 +108,7 @@ func (r *recordResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	record, err := createRecordAPI(
-		ctx, r.client,
-		plan.DomainName.ValueString(),
-		plan.Host.ValueString(),
-		plan.RecordType.ValueString(),
-		plan.Answer.ValueString(),
-	)
+	record, err := createRecordAPI(ctx, r.client, apiRecordFromModel(plan))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating record", err.Error())
 
@@ -177,13 +177,7 @@ func (r *recordResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	record, err := updateRecordAPI(
-		ctx, r.client, recordID,
-		plan.DomainName.ValueString(),
-		plan.Host.ValueString(),
-		plan.RecordType.ValueString(),
-		plan.Answer.ValueString(),
-	)
+	record, err := updateRecordAPI(ctx, r.client, recordID, apiRecordFromModel(plan))
 	if err != nil {
 		// The record was deleted outside Terraform between plan and apply: drop
 		// it from state so the next plan recreates it, matching the Read path.
@@ -294,8 +288,27 @@ func recordReadState(state recordModel, record *namecom.Record) recordModel {
 	state.Host = reconcileHostValue(state.Host, record.Host)
 	state.RecordType = reconcileDNSValue(state.RecordType, record.Type)
 	state.Answer = reconcileDNSValue(state.Answer, record.Answer)
+	state.Priority = reconcilePriority(state.Priority, record.Priority)
 
 	return state
+}
+
+// reconcilePriority keeps an unset priority (null) when the API reports the
+// zero default: record types that do not use priority always report 0, which
+// would otherwise surface as perpetual drift against a config that omits the
+// attribute. A configured value that matches the API is preserved as-is; any
+// genuine difference is adopted from the API, so an MX record's priority is
+// populated on import and real out-of-band changes are still detected.
+func reconcilePriority(prior types.Int32, apiValue uint32) types.Int32 {
+	if prior.IsNull() && apiValue == 0 {
+		return prior
+	}
+
+	if !prior.IsNull() && priorityToUint32(prior) == apiValue {
+		return prior
+	}
+
+	return types.Int32Value(priorityToInt32(apiValue))
 }
 
 // reconcileDNSValue keeps the prior state value when it is semantically equal
@@ -357,23 +370,46 @@ func requiresReplaceOnDNSChange() planmodifier.String {
 	)
 }
 
+// apiRecordFromModel builds the Name.com API record from the user-controlled
+// attributes of the plan. The server-assigned id is set separately by the
+// callers that need it (Update).
+func apiRecordFromModel(model recordModel) *namecom.Record {
+	return &namecom.Record{
+		DomainName: model.DomainName.ValueString(),
+		Host:       model.Host.ValueString(),
+		Type:       model.RecordType.ValueString(),
+		Answer:     model.Answer.ValueString(),
+		Priority:   priorityToUint32(model.Priority),
+	}
+}
+
+// priorityToUint32 converts the optional priority attribute to the uint32 the
+// API expects. An unset, unknown, or negative value maps to 0, which the API
+// ignores for record types that do not use priority.
+func priorityToUint32(priority types.Int32) uint32 {
+	if priority.IsNull() || priority.IsUnknown() || priority.ValueInt32() < 0 {
+		return 0
+	}
+
+	//nolint:gosec // Guarded above: the value is non-negative, so it fits in uint32.
+	return uint32(priority.ValueInt32())
+}
+
+// priorityToInt32 converts an API priority back to the schema's int32. DNS
+// priority is a 16-bit field, so the value always fits in int32.
+func priorityToInt32(apiValue uint32) int32 {
+	//nolint:gosec // DNS priority is a 16-bit field; it always fits in int32.
+	return int32(apiValue)
+}
+
 // createRecordAPI creates a record via the Name.com API.
-func createRecordAPI(
-	ctx context.Context,
-	client *namecom.NameCom,
-	domainName, host, recordType, answer string,
-) (*namecom.Record, error) {
+func createRecordAPI(ctx context.Context, client *namecom.NameCom, input *namecom.Record) (*namecom.Record, error) {
 	err := RespectRateLimits(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "rate limiting error")
 	}
 
-	record, err := client.CreateRecord(&namecom.Record{
-		DomainName: domainName,
-		Host:       host,
-		Type:       recordType,
-		Answer:     answer,
-	})
+	record, err := client.CreateRecord(input)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error CreateRecord")
 	}
@@ -400,24 +436,15 @@ func readRecordAPI(ctx context.Context, client *namecom.NameCom, domainName stri
 }
 
 // updateRecordAPI updates a record via the Name.com API.
-func updateRecordAPI(
-	ctx context.Context,
-	client *namecom.NameCom,
-	recordID int32,
-	domainName, host, recordType, answer string,
-) (*namecom.Record, error) {
+func updateRecordAPI(ctx context.Context, client *namecom.NameCom, recordID int32, input *namecom.Record) (*namecom.Record, error) {
 	err := RespectRateLimits(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "rate limiting error")
 	}
 
-	record, err := client.UpdateRecord(&namecom.Record{
-		ID:         recordID,
-		DomainName: domainName,
-		Host:       host,
-		Type:       recordType,
-		Answer:     answer,
-	})
+	input.ID = recordID
+
+	record, err := client.UpdateRecord(input)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error UpdateRecord")
 	}

--- a/namedotcom/resource_namedotcom_record.go
+++ b/namedotcom/resource_namedotcom_record.go
@@ -2,25 +2,41 @@ package namedotcom
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/namedotcom/go/v4/namecom"
 )
 
+// priorityMin and priorityMax bound the DNS priority field (a 16-bit value).
+const (
+	priorityMin = 0
+	priorityMax = 65535
+)
+
+// Record types that use the priority field; priority is rejected for all others.
+const (
+	recordTypeMX  = "MX"
+	recordTypeSRV = "SRV"
+)
+
 // Ensure the resource satisfies the required framework interfaces.
 var (
-	_ resource.Resource                = (*recordResource)(nil)
-	_ resource.ResourceWithConfigure   = (*recordResource)(nil)
-	_ resource.ResourceWithImportState = (*recordResource)(nil)
+	_ resource.Resource                   = (*recordResource)(nil)
+	_ resource.ResourceWithConfigure      = (*recordResource)(nil)
+	_ resource.ResourceWithImportState    = (*recordResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*recordResource)(nil)
 )
 
 // recordResource manages a single Name.com DNS record.
@@ -83,7 +99,8 @@ func (r *recordResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Description: "Answer is the record value: the IP address for A and AAAA records, the target for ANAME, CNAME, MX, NS, and SRV records, or the text for TXT records.",
 			},
 			keyPriority: schema.Int32Attribute{
-				Optional: true,
+				Optional:   true,
+				Validators: []validator.Int32{int32validator.Between(priorityMin, priorityMax)},
 				//nolint:lll // One sentence describing where priority applies.
 				Description: "Priority is used by MX and SRV records, where a lower value is preferred; it is ignored for all other record types. Valid range is 0-65535.",
 			},
@@ -98,6 +115,40 @@ func (r *recordResource) Configure(_ context.Context, req resource.ConfigureRequ
 	}
 
 	r.client = client
+}
+
+// ValidateConfig rejects a priority set on a record type that ignores it: only
+// MX and SRV records use priority. Name.com silently drops priority for other
+// types, so without this check such a config would produce a perpetual plan
+// diff (configured value vs the zero the API stores).
+func (r *recordResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config recordModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Nothing to validate when priority is unset, or when the type is not yet
+	// known (computed from another resource): defer to apply-time behaviour.
+	if config.Priority.IsNull() || config.Priority.IsUnknown() {
+		return
+	}
+
+	if config.RecordType.IsNull() || config.RecordType.IsUnknown() {
+		return
+	}
+
+	switch strings.ToUpper(config.RecordType.ValueString()) {
+	case recordTypeMX, recordTypeSRV:
+		return
+	default:
+		resp.Diagnostics.AddAttributeError(
+			path.Root(keyPriority),
+			"Priority not supported for this record type",
+			fmt.Sprintf("priority applies only to MX and SRV records, but record_type is %q.", config.RecordType.ValueString()),
+		)
+	}
 }
 
 func (r *recordResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -384,14 +435,14 @@ func apiRecordFromModel(model recordModel) *namecom.Record {
 }
 
 // priorityToUint32 converts the optional priority attribute to the uint32 the
-// API expects. An unset, unknown, or negative value maps to 0, which the API
-// ignores for record types that do not use priority.
+// API expects. An unset or unknown value maps to 0; any concrete value is in
+// the validated 0-65535 range, so the conversion is always in bounds.
 func priorityToUint32(priority types.Int32) uint32 {
-	if priority.IsNull() || priority.IsUnknown() || priority.ValueInt32() < 0 {
+	if priority.IsNull() || priority.IsUnknown() {
 		return 0
 	}
 
-	//nolint:gosec // Guarded above: the value is non-negative, so it fits in uint32.
+	//nolint:gosec // The schema validator constrains priority to 0-65535.
 	return uint32(priority.ValueInt32())
 }
 

--- a/namedotcom/resource_test.go
+++ b/namedotcom/resource_test.go
@@ -69,10 +69,20 @@ func TestRecordResource_Schema(t *testing.T) {
 	res := namedotcom.NewRecordResource()
 	attrs := resourceSchema(t, res).Attributes
 
-	for _, field := range []string{"id", "record_id", "domain_name", "host", "record_type", "answer"} {
+	for _, field := range []string{"id", "record_id", "domain_name", "host", "record_type", "answer", "priority"} {
 		if _, ok := attrs[field]; !ok {
 			t.Errorf("record schema missing attribute %q", field)
 		}
+	}
+
+	// priority is an optional Int32 used by MX/SRV records; it must be settable
+	// and not force replacement (it can be updated in place).
+	if !attrs["priority"].IsOptional() {
+		t.Error("priority should be optional")
+	}
+
+	if _, ok := attrs["priority"].(rschema.Int32Attribute); !ok {
+		t.Errorf("priority should be an Int32 attribute, got %T", attrs["priority"])
 	}
 
 	if !attrs["id"].IsComputed() {

--- a/namedotcom/schema_keys.go
+++ b/namedotcom/schema_keys.go
@@ -8,6 +8,7 @@ const (
 	keyHost               = "host"
 	keyRecordType         = "record_type"
 	keyAnswer             = "answer"
+	keyPriority           = "priority"
 	keyRecordID           = "record_id"
 	keyKeyTag             = "key_tag"
 	keyAlgorithm          = "algorithm"

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/LICENSE
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/LICENSE
@@ -1,0 +1,356 @@
+Copyright (c) 2022 HashiCorp, Inc.
+
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag/diag.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag/diag.go
@@ -1,0 +1,97 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validatordiag
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// InvalidBlockDiagnostic returns an error Diagnostic to be used when a block is invalid
+func InvalidBlockDiagnostic(path path.Path, description string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		"Invalid Block",
+		fmt.Sprintf("Block %s %s", path, description),
+	)
+}
+
+// InvalidAttributeValueDiagnostic returns an error Diagnostic to be used when an attribute has an invalid value.
+func InvalidAttributeValueDiagnostic(path path.Path, description string, value string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		"Invalid Attribute Value",
+		fmt.Sprintf("Attribute %s %s, got: %s", path, description, value),
+	)
+}
+
+// InvalidAttributeValueLengthDiagnostic returns an error Diagnostic to be used when an attribute's value has an invalid length.
+func InvalidAttributeValueLengthDiagnostic(path path.Path, description string, value string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		"Invalid Attribute Value Length",
+		fmt.Sprintf("Attribute %s %s, got: %s", path, description, value),
+	)
+}
+
+// InvalidAttributeValueMatchDiagnostic returns an error Diagnostic to be used when an attribute's value has an invalid match.
+func InvalidAttributeValueMatchDiagnostic(path path.Path, description string, value string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		"Invalid Attribute Value Match",
+		fmt.Sprintf("Attribute %s %s, got: %s", path, description, value),
+	)
+}
+
+// InvalidAttributeCombinationDiagnostic returns an error Diagnostic to be used when a schemavalidator of attributes is invalid.
+func InvalidAttributeCombinationDiagnostic(path path.Path, description string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		"Invalid Attribute Combination",
+		capitalize(description),
+	)
+}
+
+// InvalidAttributeTypeDiagnostic returns an error Diagnostic to be used when an attribute has an invalid type.
+func InvalidAttributeTypeDiagnostic(path path.Path, description string, value string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		"Invalid Attribute Type",
+		fmt.Sprintf("Attribute %s %s, got: %s", path, description, value),
+	)
+}
+
+func BugInProviderDiagnostic(summary string) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(summary,
+		"This is a bug in the provider, which should be reported in the provider's own issue tracker",
+	)
+}
+
+func InvalidValidatorUsageDiagnostic(path path.Path, validatorName string, description string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		"Invalid Validator Usage",
+		fmt.Sprintf("When validating the schema, an implementation issue was found. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			"An invalid usage of the %q validator was found: %s",
+			validatorName,
+			description,
+		),
+	)
+}
+
+// capitalize will uppercase the first letter in a UTF-8 string.
+func capitalize(str string) string {
+	if str == "" {
+		return ""
+	}
+
+	firstRune, size := utf8.DecodeRuneInString(str)
+
+	return string(unicode.ToUpper(firstRune)) + str[size:]
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package validatordiag provides diagnostics helpers for validator implementations.
+package validatordiag

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package validatorfuncerr provides error helpers for provider-defined function validators.
+package validatorfuncerr

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr/funcerr.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr/funcerr.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validatorfuncerr
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+
+func InvalidParameterValueFuncError(argumentPosition int64, description string, value string) *function.FuncError {
+	return function.NewArgumentFuncError(
+		argumentPosition,
+		fmt.Sprintf("Invalid Parameter Value: %s, got: %s", description, value),
+	)
+}
+
+func InvalidParameterValueLengthFuncError(argumentPosition int64, description string, value string) *function.FuncError {
+	return function.NewArgumentFuncError(
+		argumentPosition,
+		fmt.Sprintf("Invalid Parameter Value Length: %s, got: %s", description, value),
+	)
+}
+
+func InvalidParameterValueMatchFuncError(argumentPosition int64, description string, value string) *function.FuncError {
+	return function.NewArgumentFuncError(
+		argumentPosition,
+		fmt.Sprintf("Invalid Parameter Value Match: %s, got: %s", description, value),
+	)
+}
+
+func InvalidValidatorUsageFuncError(argumentPosition int64, validatorName string, description string) *function.FuncError {
+	return function.NewArgumentFuncError(
+		argumentPosition,
+		fmt.Sprintf(
+			"Invalid Validator Usage: "+
+				"When validating the function definition, an implementation issue was found. "+
+				"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+				"An invalid usage of the %q validator was found: %s",
+			validatorName,
+			description,
+		),
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/all.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/all.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// All returns a validator which ensures that any configured attribute value
+// attribute value validates against all the given validators.
+//
+// Use of All is only necessary when used in conjunction with Any or AnyWithAllWarnings
+// as the Validators field automatically applies a logical AND.
+func All(validators ...validator.Int32) validator.Int32 {
+	return allValidator{
+		validators: validators,
+	}
+}
+
+var _ validator.Int32 = allValidator{}
+
+// allValidator implements the validator.
+type allValidator struct {
+	validators []validator.Int32
+}
+
+// Description describes the validation in plain text formatting.
+func (v allValidator) Description(ctx context.Context) string {
+	var descriptions []string
+
+	for _, subValidator := range v.validators {
+		descriptions = append(descriptions, subValidator.Description(ctx))
+	}
+
+	return fmt.Sprintf("Value must satisfy all of the validations: %s", strings.Join(descriptions, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v allValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateInt32 performs the validation.
+func (v allValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	for _, subValidator := range v.validators {
+		validateResp := &validator.Int32Response{}
+
+		subValidator.ValidateInt32(ctx, req, validateResp)
+
+		resp.Diagnostics.Append(validateResp.Diagnostics...)
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/also_requires.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/also_requires.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator"
+)
+
+// AlsoRequires checks that a set of path.Expression has a non-null value,
+// if the current attribute also has a non-null value.
+//
+// This implements the validation logic declaratively within the schema.
+// Refer to [datasourcevalidator.RequiredTogether],
+// [providervalidator.RequiredTogether], or [resourcevalidator.RequiredTogether]
+// for declaring this type of validation outside the schema definition.
+//
+// Relative path.Expression will be resolved using the attribute being
+// validated.
+func AlsoRequires(expressions ...path.Expression) validator.Int32 {
+	return schemavalidator.AlsoRequiresValidator{
+		PathExpressions: expressions,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/any.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/any.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// Any returns a validator which ensures that any configured attribute value
+// passes at least one of the given validators.
+//
+// To prevent practitioner confusion should non-passing validators have
+// conflicting logic, only warnings from the passing validator are returned.
+// Use AnyWithAllWarnings() to return warnings from non-passing validators
+// as well.
+func Any(validators ...validator.Int32) validator.Int32 {
+	return anyValidator{
+		validators: validators,
+	}
+}
+
+var _ validator.Int32 = anyValidator{}
+
+// anyValidator implements the validator.
+type anyValidator struct {
+	validators []validator.Int32
+}
+
+// Description describes the validation in plain text formatting.
+func (v anyValidator) Description(ctx context.Context) string {
+	var descriptions []string
+
+	for _, subValidator := range v.validators {
+		descriptions = append(descriptions, subValidator.Description(ctx))
+	}
+
+	return fmt.Sprintf("Value must satisfy at least one of the validations: %s", strings.Join(descriptions, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v anyValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateInt32 performs the validation.
+func (v anyValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	for _, subValidator := range v.validators {
+		validateResp := &validator.Int32Response{}
+
+		subValidator.ValidateInt32(ctx, req, validateResp)
+
+		if !validateResp.Diagnostics.HasError() {
+			resp.Diagnostics = validateResp.Diagnostics
+
+			return
+		}
+
+		resp.Diagnostics.Append(validateResp.Diagnostics...)
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/any_with_all_warnings.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/any_with_all_warnings.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// AnyWithAllWarnings returns a validator which ensures that any configured
+// attribute value passes at least one of the given validators. This validator
+// returns all warnings, including failed validators.
+//
+// Use Any() to return warnings only from the passing validator.
+func AnyWithAllWarnings(validators ...validator.Int32) validator.Int32 {
+	return anyWithAllWarningsValidator{
+		validators: validators,
+	}
+}
+
+var _ validator.Int32 = anyWithAllWarningsValidator{}
+
+// anyWithAllWarningsValidator implements the validator.
+type anyWithAllWarningsValidator struct {
+	validators []validator.Int32
+}
+
+// Description describes the validation in plain text formatting.
+func (v anyWithAllWarningsValidator) Description(ctx context.Context) string {
+	var descriptions []string
+
+	for _, subValidator := range v.validators {
+		descriptions = append(descriptions, subValidator.Description(ctx))
+	}
+
+	return fmt.Sprintf("Value must satisfy at least one of the validations: %s", strings.Join(descriptions, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v anyWithAllWarningsValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateInt32 performs the validation.
+func (v anyWithAllWarningsValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	anyValid := false
+
+	for _, subValidator := range v.validators {
+		validateResp := &validator.Int32Response{}
+
+		subValidator.ValidateInt32(ctx, req, validateResp)
+
+		if !validateResp.Diagnostics.HasError() {
+			anyValid = true
+		}
+
+		resp.Diagnostics.Append(validateResp.Diagnostics...)
+	}
+
+	if anyValid {
+		resp.Diagnostics = resp.Diagnostics.Warnings()
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_least.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_least.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr"
+)
+
+var _ validator.Int32 = atLeastValidator{}
+var _ function.Int32ParameterValidator = atLeastValidator{}
+
+type atLeastValidator struct {
+	min int32
+}
+
+func (validator atLeastValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("value must be at least %d", validator.min)
+}
+
+func (validator atLeastValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+func (v atLeastValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if request.ConfigValue.ValueInt32() < v.min {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			v.Description(ctx),
+			fmt.Sprintf("%d", request.ConfigValue.ValueInt32()),
+		))
+	}
+}
+
+func (v atLeastValidator) ValidateParameterInt32(ctx context.Context, request function.Int32ParameterValidatorRequest, response *function.Int32ParameterValidatorResponse) {
+	if request.Value.IsNull() || request.Value.IsUnknown() {
+		return
+	}
+
+	if request.Value.ValueInt32() < v.min {
+		response.Error = validatorfuncerr.InvalidParameterValueFuncError(
+			request.ArgumentPosition,
+			v.Description(ctx),
+			fmt.Sprintf("%d", request.Value.ValueInt32()),
+		)
+	}
+}
+
+// AtLeast returns an AttributeValidator which ensures that any configured
+// attribute or function parameter value:
+//
+//   - Is a number, which can be represented by a 32-bit integer.
+//   - Is greater than or equal to the given minimum.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AtLeast(minVal int32) atLeastValidator {
+	return atLeastValidator{
+		min: minVal,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_least_one_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_least_one_of.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator"
+)
+
+// AtLeastOneOf checks that of a set of path.Expression,
+// including the attribute this validator is applied to,
+// at least one has a non-null value.
+//
+// This implements the validation logic declaratively within the tfsdk.Schema.
+// Refer to [datasourcevalidator.AtLeastOneOf],
+// [providervalidator.AtLeastOneOf], or [resourcevalidator.AtLeastOneOf]
+// for declaring this type of validation outside the schema definition.
+//
+// Any relative path.Expression will be resolved using the attribute being
+// validated.
+func AtLeastOneOf(expressions ...path.Expression) validator.Int32 {
+	return schemavalidator.AtLeastOneOfValidator{
+		PathExpressions: expressions,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_least_sum_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_least_sum_of.go
@@ -1,0 +1,116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+)
+
+var _ validator.Int32 = atLeastSumOfValidator{}
+
+// atLeastSumOfValidator validates that an integer Attribute's value is at least the sum of one
+// or more integer Attributes retrieved via the given path expressions.
+type atLeastSumOfValidator struct {
+	attributesToSumPathExpressions path.Expressions
+}
+
+// Description describes the validation in plain text formatting.
+func (av atLeastSumOfValidator) Description(_ context.Context) string {
+	var attributePaths []string
+	for _, p := range av.attributesToSumPathExpressions {
+		attributePaths = append(attributePaths, p.String())
+	}
+
+	return fmt.Sprintf("value must be at least sum of %s", strings.Join(attributePaths, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (av atLeastSumOfValidator) MarkdownDescription(ctx context.Context) string {
+	return av.Description(ctx)
+}
+
+// ValidateInt32 performs the validation.
+func (av atLeastSumOfValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Ensure input path expressions resolution against the current attribute
+	expressions := request.PathExpression.MergeExpressions(av.attributesToSumPathExpressions...)
+
+	// Sum the value of all the attributes involved, but only if they are all known.
+	var sumOfAttribs int32
+	for _, expression := range expressions {
+		matchedPaths, diags := request.Config.PathMatches(ctx, expression)
+		response.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(request.Path) {
+				continue
+			}
+
+			// Get the value
+			var matchedValue attr.Value
+			diags := request.Config.GetAttribute(ctx, mp, &matchedValue)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
+				continue
+			}
+
+			if matchedValue.IsUnknown() {
+				return
+			}
+
+			if matchedValue.IsNull() {
+				continue
+			}
+
+			// We know there is a value, convert it to the expected type
+			var attribToSum types.Int32
+			diags = tfsdk.ValueAs(ctx, matchedValue, &attribToSum)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
+				continue
+			}
+
+			sumOfAttribs += attribToSum.ValueInt32()
+		}
+	}
+
+	if request.ConfigValue.ValueInt32() < sumOfAttribs {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			av.Description(ctx),
+			fmt.Sprintf("%d", request.ConfigValue.ValueInt32()),
+		))
+	}
+}
+
+// AtLeastSumOf returns an AttributeValidator which ensures that any configured
+// attribute value:
+//
+//   - Is a number, which can be represented by a 32-bit integer.
+//   - Is at least the sum of the attributes retrieved via the given path expression(s).
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AtLeastSumOf(attributesToSumPathExpressions ...path.Expression) validator.Int32 {
+	return atLeastSumOfValidator{attributesToSumPathExpressions}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_most.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_most.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr"
+)
+
+var _ validator.Int32 = atMostValidator{}
+var _ function.Int32ParameterValidator = atMostValidator{}
+
+type atMostValidator struct {
+	max int32
+}
+
+func (validator atMostValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("value must be at most %d", validator.max)
+}
+
+func (validator atMostValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+func (v atMostValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if request.ConfigValue.ValueInt32() > v.max {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			v.Description(ctx),
+			fmt.Sprintf("%d", request.ConfigValue.ValueInt32()),
+		))
+	}
+}
+
+func (v atMostValidator) ValidateParameterInt32(ctx context.Context, request function.Int32ParameterValidatorRequest, response *function.Int32ParameterValidatorResponse) {
+	if request.Value.IsNull() || request.Value.IsUnknown() {
+		return
+	}
+
+	if request.Value.ValueInt32() > v.max {
+		response.Error = validatorfuncerr.InvalidParameterValueFuncError(
+			request.ArgumentPosition,
+			v.Description(ctx),
+			fmt.Sprintf("%d", request.Value.ValueInt32()),
+		)
+	}
+}
+
+// AtMost returns an AttributeValidator which ensures that any configured
+// attribute or function parameter value:
+//
+//   - Is a number, which can be represented by a 32-bit integer.
+//   - Is less than or equal to the given maximum.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AtMost(maxVal int32) atMostValidator {
+	return atMostValidator{
+		max: maxVal,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_most_sum_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/at_most_sum_of.go
@@ -1,0 +1,116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+)
+
+var _ validator.Int32 = atMostSumOfValidator{}
+
+// atMostSumOfValidator validates that an integer Attribute's value is at most the sum of one
+// or more integer Attributes retrieved via the given path expressions.
+type atMostSumOfValidator struct {
+	attributesToSumPathExpressions path.Expressions
+}
+
+// Description describes the validation in plain text formatting.
+func (av atMostSumOfValidator) Description(_ context.Context) string {
+	var attributePaths []string
+	for _, p := range av.attributesToSumPathExpressions {
+		attributePaths = append(attributePaths, p.String())
+	}
+
+	return fmt.Sprintf("value must be at most sum of %s", strings.Join(attributePaths, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (av atMostSumOfValidator) MarkdownDescription(ctx context.Context) string {
+	return av.Description(ctx)
+}
+
+// ValidateInt32 performs the validation.
+func (av atMostSumOfValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Ensure input path expressions resolution against the current attribute
+	expressions := request.PathExpression.MergeExpressions(av.attributesToSumPathExpressions...)
+
+	// Sum the value of all the attributes involved, but only if they are all known.
+	var sumOfAttribs int32
+	for _, expression := range expressions {
+		matchedPaths, diags := request.Config.PathMatches(ctx, expression)
+		response.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(request.Path) {
+				continue
+			}
+
+			// Get the value
+			var matchedValue attr.Value
+			diags := request.Config.GetAttribute(ctx, mp, &matchedValue)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
+				continue
+			}
+
+			if matchedValue.IsUnknown() {
+				return
+			}
+
+			if matchedValue.IsNull() {
+				continue
+			}
+
+			// We know there is a value, convert it to the expected type
+			var attribToSum types.Int32
+			diags = tfsdk.ValueAs(ctx, matchedValue, &attribToSum)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
+				continue
+			}
+
+			sumOfAttribs += attribToSum.ValueInt32()
+		}
+	}
+
+	if request.ConfigValue.ValueInt32() > sumOfAttribs {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			av.Description(ctx),
+			fmt.Sprintf("%d", request.ConfigValue.ValueInt32()),
+		))
+	}
+}
+
+// AtMostSumOf returns an AttributeValidator which ensures that any configured
+// attribute value:
+//
+//   - Is a number, which can be represented by a 32-bit integer.
+//   - Is at most the sum of the given attributes retrieved via the given path expression(s).
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AtMostSumOf(attributesToSumPathExpressions ...path.Expression) validator.Int32 {
+	return atMostSumOfValidator{attributesToSumPathExpressions}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/between.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/between.go
@@ -1,0 +1,103 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr"
+)
+
+var _ validator.Int32 = betweenValidator{}
+var _ function.Int32ParameterValidator = betweenValidator{}
+
+type betweenValidator struct {
+	min, max int32
+}
+
+func (validator betweenValidator) invalidUsageMessage() string {
+	return fmt.Sprintf("minVal cannot be greater than maxVal - minVal: %d, maxVal: %d", validator.min, validator.max)
+}
+
+func (validator betweenValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("value must be between %d and %d", validator.min, validator.max)
+}
+
+func (validator betweenValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+func (v betweenValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	// Return an error if the validator has been created in an invalid state
+	if v.min > v.max {
+		response.Diagnostics.Append(
+			validatordiag.InvalidValidatorUsageDiagnostic(
+				request.Path,
+				"Between",
+				v.invalidUsageMessage(),
+			),
+		)
+
+		return
+	}
+
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if request.ConfigValue.ValueInt32() < v.min || request.ConfigValue.ValueInt32() > v.max {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			v.Description(ctx),
+			fmt.Sprintf("%d", request.ConfigValue.ValueInt32()),
+		))
+	}
+}
+
+func (v betweenValidator) ValidateParameterInt32(ctx context.Context, request function.Int32ParameterValidatorRequest, response *function.Int32ParameterValidatorResponse) {
+	// Return an error if the validator has been created in an invalid state
+	if v.min > v.max {
+		response.Error = validatorfuncerr.InvalidValidatorUsageFuncError(
+			request.ArgumentPosition,
+			"Between",
+			v.invalidUsageMessage(),
+		)
+
+		return
+	}
+
+	if request.Value.IsNull() || request.Value.IsUnknown() {
+		return
+	}
+
+	if request.Value.ValueInt32() < v.min || request.Value.ValueInt32() > v.max {
+		response.Error = validatorfuncerr.InvalidParameterValueFuncError(
+			request.ArgumentPosition,
+			v.Description(ctx),
+			fmt.Sprintf("%d", request.Value.ValueInt32()),
+		)
+	}
+}
+
+// Between returns an AttributeValidator which ensures that any configured
+// attribute or function parameter value:
+//
+//   - Is a number, which can be represented by a 32-bit integer.
+//   - Is greater than or equal to the given minimum and less than or equal to the given maximum.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+//
+// minVal cannot be greater than maxVal. Invalid combinations of
+// minVal and maxVal will result in an implementation error message during validation.
+func Between(minVal, maxVal int32) betweenValidator {
+	return betweenValidator{
+		min: minVal,
+		max: maxVal,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/conflicts_with.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/conflicts_with.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator"
+)
+
+// ConflictsWith checks that a set of path.Expression,
+// including the attribute the validator is applied to,
+// do not have a value simultaneously.
+//
+// This implements the validation logic declaratively within the schema.
+// Refer to [datasourcevalidator.Conflicting],
+// [providervalidator.Conflicting], or [resourcevalidator.Conflicting]
+// for declaring this type of validation outside the schema definition.
+//
+// Relative path.Expression will be resolved using the attribute being
+// validated.
+func ConflictsWith(expressions ...path.Expression) validator.Int32 {
+	return schemavalidator.ConflictsWithValidator{
+		PathExpressions: expressions,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package int32validator provides validators for types.Int32 attributes or function parameters.
+package int32validator

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/equal_to_product_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/equal_to_product_of.go
@@ -1,0 +1,116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+)
+
+var _ validator.Int32 = equalToProductOfValidator{}
+
+// equalToProductOfValidator validates that an integer Attribute's value equals the product of one
+// or more integer Attributes retrieved via the given path expressions.
+type equalToProductOfValidator struct {
+	attributesToMultiplyPathExpressions path.Expressions
+}
+
+// Description describes the validation in plain text formatting.
+func (av equalToProductOfValidator) Description(_ context.Context) string {
+	var attributePaths []string
+	for _, p := range av.attributesToMultiplyPathExpressions {
+		attributePaths = append(attributePaths, p.String())
+	}
+
+	return fmt.Sprintf("value must be equal to the product of %s", strings.Join(attributePaths, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (av equalToProductOfValidator) MarkdownDescription(ctx context.Context) string {
+	return av.Description(ctx)
+}
+
+// ValidateInt32 performs the validation.
+func (av equalToProductOfValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Ensure input path expressions resolution against the current attribute
+	expressions := request.PathExpression.MergeExpressions(av.attributesToMultiplyPathExpressions...)
+
+	// Multiply the value of all the attributes involved, but only if they are all known.
+	productOfAttribs := int32(1)
+	for _, expression := range expressions {
+		matchedPaths, diags := request.Config.PathMatches(ctx, expression)
+		response.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(request.Path) {
+				continue
+			}
+
+			// Get the value
+			var matchedValue attr.Value
+			diags := request.Config.GetAttribute(ctx, mp, &matchedValue)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
+				continue
+			}
+
+			if matchedValue.IsUnknown() {
+				return
+			}
+
+			if matchedValue.IsNull() {
+				return
+			}
+
+			// We know there is a value, convert it to the expected type
+			var attribToMultiply types.Int32
+			diags = tfsdk.ValueAs(ctx, matchedValue, &attribToMultiply)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
+				continue
+			}
+
+			productOfAttribs *= attribToMultiply.ValueInt32()
+		}
+	}
+
+	if request.ConfigValue.ValueInt32() != productOfAttribs {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			av.Description(ctx),
+			fmt.Sprintf("%d", request.ConfigValue.ValueInt32()),
+		))
+	}
+}
+
+// EqualToProductOf returns an AttributeValidator which ensures that any configured
+// attribute value:
+//
+//   - Is a number, which can be represented by a 32-bit integer.
+//   - Is equal to the product of the given attributes retrieved via the given path expression(s).
+//
+// Validation is skipped if any null (unconfigured) and/or unknown (known after apply) values are present.
+func EqualToProductOf(attributesToMultiplyPathExpressions ...path.Expression) validator.Int32 {
+	return equalToProductOfValidator{attributesToMultiplyPathExpressions}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/equal_to_sum_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/equal_to_sum_of.go
@@ -1,0 +1,116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+)
+
+var _ validator.Int32 = equalToSumOfValidator{}
+
+// equalToSumOfValidator validates that an integer Attribute's value equals the sum of one
+// or more integer Attributes retrieved via the given path expressions.
+type equalToSumOfValidator struct {
+	attributesToSumPathExpressions path.Expressions
+}
+
+// Description describes the validation in plain text formatting.
+func (av equalToSumOfValidator) Description(_ context.Context) string {
+	var attributePaths []string
+	for _, p := range av.attributesToSumPathExpressions {
+		attributePaths = append(attributePaths, p.String())
+	}
+
+	return fmt.Sprintf("value must be equal to the sum of %s", strings.Join(attributePaths, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (av equalToSumOfValidator) MarkdownDescription(ctx context.Context) string {
+	return av.Description(ctx)
+}
+
+// ValidateInt32 performs the validation.
+func (av equalToSumOfValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Ensure input path expressions resolution against the current attribute
+	expressions := request.PathExpression.MergeExpressions(av.attributesToSumPathExpressions...)
+
+	// Sum the value of all the attributes involved, but only if they are all known.
+	var sumOfAttribs int32
+	for _, expression := range expressions {
+		matchedPaths, diags := request.Config.PathMatches(ctx, expression)
+		response.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(request.Path) {
+				continue
+			}
+
+			// Get the value
+			var matchedValue attr.Value
+			diags := request.Config.GetAttribute(ctx, mp, &matchedValue)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
+				continue
+			}
+
+			if matchedValue.IsUnknown() {
+				return
+			}
+
+			if matchedValue.IsNull() {
+				continue
+			}
+
+			// We know there is a value, convert it to the expected type
+			var attribToSum types.Int32
+			diags = tfsdk.ValueAs(ctx, matchedValue, &attribToSum)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
+				continue
+			}
+
+			sumOfAttribs += attribToSum.ValueInt32()
+		}
+	}
+
+	if request.ConfigValue.ValueInt32() != sumOfAttribs {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			av.Description(ctx),
+			fmt.Sprintf("%d", request.ConfigValue.ValueInt32()),
+		))
+	}
+}
+
+// EqualToSumOf returns an AttributeValidator which ensures that any configured
+// attribute value:
+//
+//   - Is a number, which can be represented by a 32-bit integer.
+//   - Is equal to the sum of the given attributes retrieved via the given path expression(s).
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func EqualToSumOf(attributesToSumPathExpressions ...path.Expression) validator.Int32 {
+	return equalToSumOfValidator{attributesToSumPathExpressions}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/exactly_one_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/exactly_one_of.go
@@ -1,0 +1,29 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator"
+)
+
+// ExactlyOneOf checks that of a set of path.Expression,
+// including the attribute the validator is applied to,
+// one and only one attribute has a value.
+// It will also cause a validation error if none are specified.
+//
+// This implements the validation logic declaratively within the schema.
+// Refer to [datasourcevalidator.ExactlyOneOf],
+// [providervalidator.ExactlyOneOf], or [resourcevalidator.ExactlyOneOf]
+// for declaring this type of validation outside the schema definition.
+//
+// Relative path.Expression will be resolved using the attribute being
+// validated.
+func ExactlyOneOf(expressions ...path.Expression) validator.Int32 {
+	return schemavalidator.ExactlyOneOfValidator{
+		PathExpressions: expressions,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/none_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/none_of.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr"
+)
+
+var _ validator.Int32 = noneOfValidator{}
+var _ function.Int32ParameterValidator = noneOfValidator{}
+
+type noneOfValidator struct {
+	values []types.Int32
+}
+
+func (v noneOfValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v noneOfValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("value must be none of: %q", v.values)
+}
+
+func (v noneOfValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue
+
+	for _, otherValue := range v.values {
+		if !value.Equal(otherValue) {
+			continue
+		}
+
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueMatchDiagnostic(
+			request.Path,
+			v.Description(ctx),
+			value.String(),
+		))
+
+		break
+	}
+}
+
+func (v noneOfValidator) ValidateParameterInt32(ctx context.Context, request function.Int32ParameterValidatorRequest, response *function.Int32ParameterValidatorResponse) {
+	if request.Value.IsNull() || request.Value.IsUnknown() {
+		return
+	}
+
+	value := request.Value
+
+	for _, otherValue := range v.values {
+		if !value.Equal(otherValue) {
+			continue
+		}
+
+		response.Error = validatorfuncerr.InvalidParameterValueMatchFuncError(
+			request.ArgumentPosition,
+			v.Description(ctx),
+			value.String(),
+		)
+
+		break
+	}
+}
+
+// NoneOf checks that the Int32 held in the attribute or function parameter
+// is none of the given `values`.
+func NoneOf(values ...int32) noneOfValidator {
+	frameworkValues := make([]types.Int32, 0, len(values))
+
+	for _, value := range values {
+		frameworkValues = append(frameworkValues, types.Int32Value(value))
+	}
+
+	return noneOfValidator{
+		values: frameworkValues,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/one_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/one_of.go
@@ -1,0 +1,85 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr"
+)
+
+var _ validator.Int32 = oneOfValidator{}
+var _ function.Int32ParameterValidator = oneOfValidator{}
+
+type oneOfValidator struct {
+	values []types.Int32
+}
+
+func (v oneOfValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v oneOfValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("value must be one of: %q", v.values)
+}
+
+func (v oneOfValidator) ValidateInt32(ctx context.Context, request validator.Int32Request, response *validator.Int32Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue
+
+	for _, otherValue := range v.values {
+		if value.Equal(otherValue) {
+			return
+		}
+	}
+
+	response.Diagnostics.Append(validatordiag.InvalidAttributeValueMatchDiagnostic(
+		request.Path,
+		v.Description(ctx),
+		value.String(),
+	))
+}
+
+func (v oneOfValidator) ValidateParameterInt32(ctx context.Context, request function.Int32ParameterValidatorRequest, response *function.Int32ParameterValidatorResponse) {
+	if request.Value.IsNull() || request.Value.IsUnknown() {
+		return
+	}
+
+	value := request.Value
+
+	for _, otherValue := range v.values {
+		if value.Equal(otherValue) {
+			return
+		}
+	}
+
+	response.Error = validatorfuncerr.InvalidParameterValueMatchFuncError(
+		request.ArgumentPosition,
+		v.Description(ctx),
+		value.String(),
+	)
+}
+
+// OneOf checks that the Int32 held in the attribute or function parameter
+// is one of the given `values`.
+func OneOf(values ...int32) oneOfValidator {
+	frameworkValues := make([]types.Int32, 0, len(values))
+
+	for _, value := range values {
+		frameworkValues = append(frameworkValues, types.Int32Value(value))
+	}
+
+	return oneOfValidator{
+		values: frameworkValues,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/prefer_write_only_attribute.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/int32validator/prefer_write_only_attribute.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32validator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator"
+)
+
+// PreferWriteOnlyAttribute returns a warning if the Terraform client supports
+// write-only attributes, and the attribute that the validator is applied to has a value.
+// It takes in a path.Expression that represents the write-only attribute schema location,
+// and the warning message will indicate that the write-only attribute should be preferred.
+//
+// This validator should only be used for resource attributes as other schema types do not
+// support write-only attributes.
+//
+// This implements the validation logic declaratively within the schema.
+// Refer to [resourcevalidator.PreferWriteOnlyAttribute]
+// for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
+func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Int32 {
+	return schemavalidator.PreferWriteOnlyAttribute{
+		WriteOnlyAttribute: writeOnlyAttribute,
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/also_requires.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/also_requires.go
@@ -1,0 +1,275 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schemavalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+)
+
+// This type of validator must satisfy all types.
+var (
+	_ validator.Bool    = AlsoRequiresValidator{}
+	_ validator.Float32 = AlsoRequiresValidator{}
+	_ validator.Float64 = AlsoRequiresValidator{}
+	_ validator.Int32   = AlsoRequiresValidator{}
+	_ validator.Int64   = AlsoRequiresValidator{}
+	_ validator.List    = AlsoRequiresValidator{}
+	_ validator.Map     = AlsoRequiresValidator{}
+	_ validator.Number  = AlsoRequiresValidator{}
+	_ validator.Object  = AlsoRequiresValidator{}
+	_ validator.Set     = AlsoRequiresValidator{}
+	_ validator.String  = AlsoRequiresValidator{}
+	_ validator.Dynamic = AlsoRequiresValidator{}
+)
+
+// AlsoRequiresValidator is the underlying struct implementing AlsoRequires.
+type AlsoRequiresValidator struct {
+	PathExpressions path.Expressions
+}
+
+type AlsoRequiresValidatorRequest struct {
+	Config         tfsdk.Config
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+}
+
+type AlsoRequiresValidatorResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (av AlsoRequiresValidator) Description(ctx context.Context) string {
+	return av.MarkdownDescription(ctx)
+}
+
+func (av AlsoRequiresValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that if an attribute is set, also these are set: %q", av.PathExpressions)
+}
+
+func (av AlsoRequiresValidator) Validate(ctx context.Context, req AlsoRequiresValidatorRequest, res *AlsoRequiresValidatorResponse) {
+	// If attribute configuration is null, there is nothing else to validate
+	// If attribute configuration is unknown, delay the validation until it is known.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	expressions := req.PathExpression.MergeExpressions(av.PathExpressions...)
+
+	for _, expression := range expressions {
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		res.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(req.Path) {
+				continue
+			}
+
+			var mpVal attr.Value
+			diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+			res.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// Delay validation until all involved attribute have a known value
+			if mpVal.IsUnknown() {
+				return
+			}
+
+			if mpVal.IsNull() {
+				res.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+					req.Path,
+					fmt.Sprintf("Attribute %q must be specified when %q is specified", mp, req.Path),
+				))
+			}
+		}
+	}
+}
+
+func (av AlsoRequiresValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateNumber(ctx context.Context, req validator.NumberRequest, resp *validator.NumberResponse) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AlsoRequiresValidator) ValidateDynamic(ctx context.Context, req validator.DynamicRequest, resp *validator.DynamicResponse) {
+	validateReq := AlsoRequiresValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AlsoRequiresValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/at_least_one_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/at_least_one_of.go
@@ -1,0 +1,275 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schemavalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+)
+
+// This type of validator must satisfy all types.
+var (
+	_ validator.Bool    = AtLeastOneOfValidator{}
+	_ validator.Float32 = AtLeastOneOfValidator{}
+	_ validator.Float64 = AtLeastOneOfValidator{}
+	_ validator.Int32   = AtLeastOneOfValidator{}
+	_ validator.Int64   = AtLeastOneOfValidator{}
+	_ validator.List    = AtLeastOneOfValidator{}
+	_ validator.Map     = AtLeastOneOfValidator{}
+	_ validator.Number  = AtLeastOneOfValidator{}
+	_ validator.Object  = AtLeastOneOfValidator{}
+	_ validator.Set     = AtLeastOneOfValidator{}
+	_ validator.String  = AtLeastOneOfValidator{}
+	_ validator.Dynamic = AtLeastOneOfValidator{}
+)
+
+// AtLeastOneOfValidator is the underlying struct implementing AtLeastOneOf.
+type AtLeastOneOfValidator struct {
+	PathExpressions path.Expressions
+}
+
+type AtLeastOneOfValidatorRequest struct {
+	Config         tfsdk.Config
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+}
+
+type AtLeastOneOfValidatorResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (av AtLeastOneOfValidator) Description(ctx context.Context) string {
+	return av.MarkdownDescription(ctx)
+}
+
+func (av AtLeastOneOfValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that at least one attribute from this collection is set: %s", av.PathExpressions)
+}
+
+func (av AtLeastOneOfValidator) Validate(ctx context.Context, req AtLeastOneOfValidatorRequest, res *AtLeastOneOfValidatorResponse) {
+	// If attribute configuration is not null, validator already succeeded.
+	// If attribute configuration is unknown, delay the validation until it is known.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	expressions := req.PathExpression.MergeExpressions(av.PathExpressions...)
+
+	for _, expression := range expressions {
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		res.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			var mpVal attr.Value
+			diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+			res.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// Delay validation until all involved attribute have a known value
+			if mpVal.IsUnknown() {
+				return
+			}
+
+			if !mpVal.IsNull() {
+				return
+			}
+		}
+	}
+
+	// This attribute is among those required attributes,
+	// append it to make it appears in the error message.
+	expressions.Append(req.PathExpression)
+
+	res.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+		req.Path,
+		fmt.Sprintf("At least one attribute out of %s must be specified", expressions),
+	))
+}
+
+func (av AtLeastOneOfValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateNumber(ctx context.Context, req validator.NumberRequest, resp *validator.NumberResponse) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av AtLeastOneOfValidator) ValidateDynamic(ctx context.Context, req validator.DynamicRequest, resp *validator.DynamicResponse) {
+	validateReq := AtLeastOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &AtLeastOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/conflicts_with.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/conflicts_with.go
@@ -1,0 +1,275 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schemavalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+)
+
+// This type of validator must satisfy all types.
+var (
+	_ validator.Bool    = ConflictsWithValidator{}
+	_ validator.Float64 = ConflictsWithValidator{}
+	_ validator.Float32 = ConflictsWithValidator{}
+	_ validator.Int32   = ConflictsWithValidator{}
+	_ validator.Int64   = ConflictsWithValidator{}
+	_ validator.List    = ConflictsWithValidator{}
+	_ validator.Map     = ConflictsWithValidator{}
+	_ validator.Number  = ConflictsWithValidator{}
+	_ validator.Object  = ConflictsWithValidator{}
+	_ validator.Set     = ConflictsWithValidator{}
+	_ validator.String  = ConflictsWithValidator{}
+	_ validator.Dynamic = ConflictsWithValidator{}
+)
+
+// ConflictsWithValidator is the underlying struct implementing ConflictsWith.
+type ConflictsWithValidator struct {
+	PathExpressions path.Expressions
+}
+
+type ConflictsWithValidatorRequest struct {
+	Config         tfsdk.Config
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+}
+
+type ConflictsWithValidatorResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (av ConflictsWithValidator) Description(ctx context.Context) string {
+	return av.MarkdownDescription(ctx)
+}
+
+func (av ConflictsWithValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that if an attribute is set, these are not set: %q", av.PathExpressions)
+}
+
+func (av ConflictsWithValidator) Validate(ctx context.Context, req ConflictsWithValidatorRequest, res *ConflictsWithValidatorResponse) {
+	// If attribute configuration is null, it cannot conflict with others
+	// If attribute configuration is unknown, delay the validation until it is known.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	expressions := req.PathExpression.MergeExpressions(av.PathExpressions...)
+
+	for _, expression := range expressions {
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		res.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(req.Path) {
+				continue
+			}
+
+			var mpVal attr.Value
+			diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+			res.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// Delay validation until all involved attribute have a known value
+			if mpVal.IsUnknown() {
+				return
+			}
+
+			if !mpVal.IsNull() {
+				res.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+					req.Path,
+					fmt.Sprintf("Attribute %q cannot be specified when %q is specified", mp, req.Path),
+				))
+			}
+		}
+	}
+}
+
+func (av ConflictsWithValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateNumber(ctx context.Context, req validator.NumberRequest, resp *validator.NumberResponse) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ConflictsWithValidator) ValidateDynamic(ctx context.Context, req validator.DynamicRequest, resp *validator.DynamicResponse) {
+	validateReq := ConflictsWithValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsWithValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/doc.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package schemavalidator provides validators to express relationships between
+// multiple attributes within the schema of a resource, data source, or provider.
+// For example, checking that an attribute is present when another is present, or vice-versa.
+//
+// These validators are implemented on a starting attribute, where
+// relationships can be expressed as absolute paths to others or relative to
+// the starting attribute. For multiple attribute validators that are defined
+// outside the schema, which may be easier to implement in provider code
+// generation situations or suit provider code preferences differently, refer
+// to the datasourcevalidator, providervalidator, or resourcevalidator package.
+package schemavalidator

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/exactly_one_of.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/exactly_one_of.go
@@ -1,0 +1,294 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schemavalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+)
+
+// This type of validator must satisfy all types.
+var (
+	_ validator.Bool    = ExactlyOneOfValidator{}
+	_ validator.Float32 = ExactlyOneOfValidator{}
+	_ validator.Float64 = ExactlyOneOfValidator{}
+	_ validator.Int32   = ExactlyOneOfValidator{}
+	_ validator.Int64   = ExactlyOneOfValidator{}
+	_ validator.List    = ExactlyOneOfValidator{}
+	_ validator.Map     = ExactlyOneOfValidator{}
+	_ validator.Number  = ExactlyOneOfValidator{}
+	_ validator.Object  = ExactlyOneOfValidator{}
+	_ validator.Set     = ExactlyOneOfValidator{}
+	_ validator.String  = ExactlyOneOfValidator{}
+	_ validator.Dynamic = ExactlyOneOfValidator{}
+)
+
+// ExactlyOneOfValidator is the underlying struct implementing ExactlyOneOf.
+type ExactlyOneOfValidator struct {
+	PathExpressions path.Expressions
+}
+
+type ExactlyOneOfValidatorRequest struct {
+	Config         tfsdk.Config
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+}
+
+type ExactlyOneOfValidatorResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (av ExactlyOneOfValidator) Description(ctx context.Context) string {
+	return av.MarkdownDescription(ctx)
+}
+
+func (av ExactlyOneOfValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that one and only one attribute from this collection is set: %q", av.PathExpressions)
+}
+
+func (av ExactlyOneOfValidator) Validate(ctx context.Context, req ExactlyOneOfValidatorRequest, res *ExactlyOneOfValidatorResponse) {
+	count := 0
+	expressions := req.PathExpression.MergeExpressions(av.PathExpressions...)
+
+	// If current attribute is unknown, delay validation
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Now that we know the current attribute is known, check whether it is
+	// null to determine if it should contribute to the count. Later logic
+	// will remove a duplicate matching path, should it be included in the
+	// given expressions.
+	if !req.ConfigValue.IsNull() {
+		count++
+	}
+
+	for _, expression := range expressions {
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		res.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(req.Path) {
+				continue
+			}
+
+			var mpVal attr.Value
+			diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+			res.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// Delay validation until all involved attribute have a known value
+			if mpVal.IsUnknown() {
+				return
+			}
+
+			if !mpVal.IsNull() {
+				count++
+			}
+		}
+	}
+
+	if count == 0 {
+		res.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+			req.Path,
+			fmt.Sprintf("No attribute specified when one (and only one) of %s is required", expressions),
+		))
+	}
+
+	if count > 1 {
+		res.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+			req.Path,
+			fmt.Sprintf("%d attributes specified when one (and only one) of %s is required", count, expressions),
+		))
+	}
+}
+
+func (av ExactlyOneOfValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateNumber(ctx context.Context, req validator.NumberRequest, resp *validator.NumberResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av ExactlyOneOfValidator) ValidateDynamic(ctx context.Context, req validator.DynamicRequest, resp *validator.DynamicResponse) {
+	validateReq := ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ExactlyOneOfValidatorResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/prefer_write_only_attribute.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator/prefer_write_only_attribute.go
@@ -1,0 +1,260 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schemavalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// This type of validator must satisfy all types.
+var (
+	_ validator.Bool    = PreferWriteOnlyAttribute{}
+	_ validator.Float32 = PreferWriteOnlyAttribute{}
+	_ validator.Float64 = PreferWriteOnlyAttribute{}
+	_ validator.Int32   = PreferWriteOnlyAttribute{}
+	_ validator.Int64   = PreferWriteOnlyAttribute{}
+	_ validator.List    = PreferWriteOnlyAttribute{}
+	_ validator.Map     = PreferWriteOnlyAttribute{}
+	_ validator.Number  = PreferWriteOnlyAttribute{}
+	_ validator.Object  = PreferWriteOnlyAttribute{}
+	_ validator.String  = PreferWriteOnlyAttribute{}
+)
+
+// PreferWriteOnlyAttribute is the underlying struct implementing ExactlyOneOf.
+type PreferWriteOnlyAttribute struct {
+	WriteOnlyAttribute path.Expression
+}
+
+type PreferWriteOnlyAttributeRequest struct {
+	ClientCapabilities validator.ValidateSchemaClientCapabilities
+	Config             tfsdk.Config
+	ConfigValue        attr.Value
+	Path               path.Path
+	PathExpression     path.Expression
+}
+
+type PreferWriteOnlyAttributeResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (av PreferWriteOnlyAttribute) Description(ctx context.Context) string {
+	return av.MarkdownDescription(ctx)
+}
+
+func (av PreferWriteOnlyAttribute) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("The write-only attribute %s should be preferred over this attribute", av.WriteOnlyAttribute)
+}
+
+func (av PreferWriteOnlyAttribute) Validate(ctx context.Context, req PreferWriteOnlyAttributeRequest, resp *PreferWriteOnlyAttributeResponse) {
+	if !req.ClientCapabilities.WriteOnlyAttributesAllowed {
+		return
+	}
+
+	oldAttributePaths, oldAttributeDiags := req.Config.PathMatches(ctx, req.PathExpression)
+	if oldAttributeDiags.HasError() {
+		resp.Diagnostics.Append(oldAttributeDiags...)
+		return
+	}
+
+	_, writeOnlyAttributeDiags := req.Config.PathMatches(ctx, av.WriteOnlyAttribute)
+	if writeOnlyAttributeDiags.HasError() {
+		resp.Diagnostics.Append(writeOnlyAttributeDiags...)
+		return
+	}
+
+	for _, mp := range oldAttributePaths {
+		// Get the value
+		var matchedValue attr.Value
+		diags := req.Config.GetAttribute(ctx, mp, &matchedValue)
+		resp.Diagnostics.Append(diags...)
+		if diags.HasError() {
+			continue
+		}
+
+		if matchedValue.IsUnknown() {
+			return
+		}
+
+		if matchedValue.IsNull() {
+			continue
+		}
+
+		resp.Diagnostics.AddAttributeWarning(mp,
+			"Available Write-Only Attribute Alternative",
+			fmt.Sprintf("This attribute has a WriteOnly version %s available. "+
+				"Use the WriteOnly version of the attribute when possible.", av.WriteOnlyAttribute.String()))
+	}
+}
+
+func (av PreferWriteOnlyAttribute) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateDynamic(ctx context.Context, req validator.DynamicRequest, resp *validator.DynamicResponse) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateNumber(ctx context.Context, req validator.NumberRequest, resp *validator.NumberResponse) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av PreferWriteOnlyAttribute) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateReq := PreferWriteOnlyAttributeRequest{
+		Config:             req.Config,
+		ConfigValue:        req.ConfigValue,
+		Path:               req.Path,
+		PathExpression:     req.PathExpression,
+		ClientCapabilities: req.ClientCapabilities,
+	}
+	validateResp := &PreferWriteOnlyAttributeResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,6 +122,12 @@ github.com/hashicorp/terraform-plugin-framework/statestore/schema
 github.com/hashicorp/terraform-plugin-framework/tfsdk
 github.com/hashicorp/terraform-plugin-framework/types
 github.com/hashicorp/terraform-plugin-framework/types/basetypes
+# github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
+## explicit; go 1.24.0
+github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag
+github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatorfuncerr
+github.com/hashicorp/terraform-plugin-framework-validators/int32validator
+github.com/hashicorp/terraform-plugin-framework-validators/internal/schemavalidator
 # github.com/hashicorp/terraform-plugin-go v0.31.0
 ## explicit; go 1.25.0
 github.com/hashicorp/terraform-plugin-go/internal/logging


### PR DESCRIPTION
## Description

Adds a `priority` attribute to `namedotcom_record` so MX and SRV records can set their priority — previously there was no way to express it. This is a new feature and is backward compatible: `priority` is optional and existing configurations are unaffected.

- `priority` is an optional Int32, validated to the 0-65535 range.
- `ValidateConfig` rejects `priority` on record types that ignore it (only MX and SRV use it), which prevents a perpetual plan diff.
- Read reconciles priority so an unset value does not flap against the API's zero default, while genuine changes (and import of an existing MX record) are reflected.
- The API translation helpers now take a `*namecom.Record` so future fields no longer grow their parameter lists.
- The README is reworked into a single realistic example covering every resource; the per-resource docs gain the priority attribute and an MX example.

Testing: `go test -race ./...` and `golangci-lint run` both pass. New tests cover the range validator boundaries, `ValidateConfig` (accepted and rejected types, defer on unknown/null), priority drift reconciliation, the priority 10 -> 0 update reset, and request-body propagation.

Components affected: `namedotcom_record` resource, its docs, and the README.

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
Add a `priority` attribute to `namedotcom_record` for MX and SRV records.
```
